### PR TITLE
Avoid potential NULL pointer dereference

### DIFF
--- a/src/config-file.c
+++ b/src/config-file.c
@@ -61,7 +61,7 @@ static gboolean get_key_string(GKeyFile *key_file, const gchar* group, const gch
 static gboolean get_key_bool(GKeyFile *key_file, const gchar* group, const gchar* key, gboolean* value, const gboolean default_value, GError **error)
 {
         g_autofree gchar *val = NULL;
-        val = g_key_file_get_string(key_file, group, key, NULL);
+        val = g_key_file_get_string(key_file, group, key, error);
         if (val == NULL) {
                 *value = default_value;
                 return TRUE;
@@ -81,7 +81,7 @@ static gboolean get_key_bool(GKeyFile *key_file, const gchar* group, const gchar
 
 static gboolean get_key_int(GKeyFile *key_file, const gchar* group, const gchar* key, gint* value, const gint default_value, GError **error)
 {
-        gint val = g_key_file_get_integer(key_file, group, key, NULL);
+        gint val = g_key_file_get_integer(key_file, group, key, error);
         if (val == 0) {
                 *value = default_value;
                 return TRUE;

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -125,8 +125,12 @@ int main(int argc, char **argv)
         context = g_option_context_new("");
         g_option_context_add_main_entries(context, entries, NULL);
         if (!g_option_context_parse_strv(context, &args, &error)) {
-                g_printerr("option parsing failed: %s\n", error->message);
-                g_error_free(error);
+                if (error != NULL) {
+                        g_printerr("option parsing failed: %s\n", error->message);
+                        g_error_free(error);
+                } else {
+                        g_printerr("option parsing failed: error unknown\n");
+                }
                 exit_code = 1;
                 goto out;
         }
@@ -155,8 +159,12 @@ int main(int argc, char **argv)
 
         struct config *config = load_config_file(config_file, &error);
         if (config == NULL) {
-                g_printerr("Loading config file failed: %s\n", error->message);
-                g_error_free(error);
+                if (error != NULL) {
+                        g_printerr("Loading config file failed: %s\n", error->message);
+                        g_error_free(error);
+                } else {
+                        g_printerr("Loading config file failed: unknown error\n");
+                }
                 exit_code = 4;
                 goto out;
         }


### PR DESCRIPTION
It is not guaranteed that error is assigned when printing error messages.