### PR TITLE
Rearranged comments in config.conf.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ Setup target (device) configuration file:
   target_name               = test-target
   auth_token                = bhVahL1Il1shie2aj2poojeChee6ahShu
   bundle_download_location  = /tmp/bundle.raucb
-  retry_wait                = 60 ; 1 min. retry wait
-  connect_timeout           = 20 ; 20 secs. connection timeout
-  timeout                   = 60 ; 1 min. timeout
-  log_level                 = debug ; debug, info, message, warning, critical
+  retry_wait                = 60
+  connect_timeout           = 20
+  timeout                   = 60
+  log_level                 = debug
 
   [device]
   product                   = Terminator
   model                     = T-1000
   serialnumber              = 8922673153
-  hw_revision               = 2  ; With working shapeshifting
+  hw_revision               = 2
   key1                      = value
   key2                      = value
 ```

--- a/config.conf.example
+++ b/config.conf.example
@@ -1,15 +1,36 @@
 [client]
-hawkbit_server            = 10.10.0.254:8080                    # host or IP and optional port
-ssl                       = false                               # true = HTTPS, false = HTTP
-ssl_verify                = false                               # validate ssl certificate (only use if ssl is true)
-tenant_id                 = DEFAULT                             # Tenant id
-target_name               = test-target                         # Target name (controller id),
-auth_token                = cb115a721af28f781b493fa467819ef5    # Security token.
-bundle_download_location  = /tmp/bundle.raucb                   # Temporay file RAUC bundle should be downloaded to.
-retry_wait                = 60                                  # time in seconds to wait before retrying.
-connect_timeout           = 20                                  # connection timeout in seconds.
-timeout                   = 60                                  # request timeout in seconds.
-log_level                 = message                             # debug, info, message, critical, error, fatal.
+# host or IP and optional port
+hawkbit_server            = 10.10.0.254:8080
+
+# true = HTTPS, false = HTTP
+ssl                       = false
+
+# validate ssl certificate (only use if ssl is true)
+ssl_verify                = false
+
+# Tenant id
+tenant_id                 = DEFAULT
+
+# Target name (controller id)
+target_name               = test-target
+
+# Security token
+auth_token                = cb115a721af28f781b493fa467819ef5
+
+# Temporay file RAUC bundle should be downloaded to
+bundle_download_location  = /tmp/bundle.raucb
+
+# time in seconds to wait before retrying
+retry_wait                = 60
+
+# connection timeout in seconds
+connect_timeout           = 20
+
+# request timeout in seconds
+timeout                   = 60
+
+# debug, info, message, critical, error, fatal
+log_level                 = message
 
 # Every key / value under [device] is sent to HawkBit (target attributes),
 # and can be used in target filter.


### PR DESCRIPTION
Rearranged the comments in the config.conf.example to avoid a
segmentation fault when parsing the configuration file.