### PR TITLE
Fix Error Handling in config-file.c

### DIFF
--- a/src/config-file.c
+++ b/src/config-file.c
@@ -211,8 +211,8 @@ struct config* load_config_file(const gchar* config_file, GError** error)
 
         if (config->timeout > 0 && config->connect_timeout > 0 && config->timeout < config->connect_timeout) {
                 g_set_error(error,
-                            1,                   // error domain
-                            5,                   // error code
+                            G_KEY_FILE_ERROR,                   // error domain
+                            G_KEY_FILE_ERROR_INVALID_VALUE,     // error code
                             "timeout should be greater than connect_timeout. Timeout: %ld, Connect timeout: %ld",
                             config->timeout,
                             config->connect_timeout

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -46,12 +46,16 @@ void config_file_free(struct config *config)
 static gboolean get_key_string(GKeyFile *key_file, const gchar* group, const gchar* key, gchar** value, const gchar* default_value, GError **error)
 {
         gchar *val = NULL;
-        val = g_key_file_get_string(key_file, group, key, error);
+        val = g_key_file_get_string(key_file, group, key, NULL);
         if (val == NULL) {
                 if (default_value != NULL) {
                         *value = g_strdup(default_value);
                         return TRUE;
                 }
+
+                g_set_error(error, G_KEY_FILE_ERROR,
+                            G_KEY_FILE_ERROR_NOT_FOUND,
+                            "Key '%s' not found in group '%s' and no default given", key, group);
                 return FALSE;
         }
         *value = val;

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -86,10 +86,17 @@ static gboolean get_key_bool(GKeyFile *key_file, const gchar* group, const gchar
 
 static gboolean get_key_int(GKeyFile *key_file, const gchar* group, const gchar* key, gint* value, const gint default_value, GError **error)
 {
-        gint val = g_key_file_get_integer(key_file, group, key, NULL);
-        if (val == 0) {
+        GError *ierror = NULL;
+        gint val = g_key_file_get_integer(key_file, group, key, &ierror);
+
+        if (val == 0 && g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+                g_clear_error(&ierror);
                 *value = default_value;
                 return TRUE;
+        }
+        else if (val == 0 && ierror) {
+                g_propagate_error(error, ierror);
+                return FALSE;
         }
         *value = val;
         return TRUE;

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -76,6 +76,11 @@ static gboolean get_key_bool(GKeyFile *key_file, const gchar* group, const gchar
                 *value = TRUE;
                 return TRUE;
         }
+
+        g_set_error(error, G_KEY_FILE_ERROR,
+                    G_KEY_FILE_ERROR_INVALID_VALUE,
+                    "Value '%s' cannot be interpreted as a boolean.", val);
+
         return FALSE;
 }
 

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -106,20 +106,20 @@ static gboolean get_key_int(GKeyFile *key_file, const gchar* group, const gchar*
         return TRUE;
 }
 
-static gboolean get_group(GKeyFile *key_file, const gchar *group, GHashTable **hash, GError *error)
+static gboolean get_group(GKeyFile *key_file, const gchar *group, GHashTable **hash, GError **error)
 {
         guint key;
         gsize num_keys;
         gchar **keys, *value;
 
         *hash = g_hash_table_new(g_str_hash, g_str_equal);
-        keys = g_key_file_get_keys(key_file, group, &num_keys, &error);
+        keys = g_key_file_get_keys(key_file, group, &num_keys, error);
         for (key = 0; key < num_keys; key++)
         {
                 value = g_key_file_get_value(key_file,
                                              group,
                                              keys[key],
-                                             &error);
+                                             error);
                 g_hash_table_insert(*hash, keys[key], value);
                 //g_debug("\t\tkey %u/%lu: \t%s => %s\n", key, num_keys - 1, keys[key], value);
         }
@@ -176,7 +176,7 @@ struct config* load_config_file(const gchar* config_file, GError** error)
                 return NULL;
         if (!get_key_bool(ini_file, "client", "ssl_verify", &config->ssl_verify, DEFAULT_SSL_VERIFY, error))
                 return NULL;
-        if (!get_group(ini_file, "device", &config->device, *error))
+        if (!get_group(ini_file, "device", &config->device, error))
                 return NULL;
 
         if (!get_key_int(ini_file, "client", "connect_timeout", &val_int, DEFAULT_CONNECTTIMEOUT, error))


### PR DESCRIPTION
This fixes the handling of GError's in config-file.c in many different ways.

As a result of this, no segmentation faults caused by unset errors should be triggered anymore and parsing of broken configuration should return valid error messages.

Fixes #23
Replaces #24