### PR TITLE
uncrustify: set sp_before_sparen to correct "add" value

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -9,7 +9,7 @@ indent_func_proto_param         = true
 indent_func_param_double        = true
 nl_fdef_brace                   = add
 align_keep_tabs                 = true
-sp_before_sparen                = true
+sp_before_sparen                = add
 # different from rauc:
 indent_with_tabs                = 0
 indent_func_call_param          = false


### PR DESCRIPTION
Per uncrustify's documentation:

```
  # Add or remove space before '(' of control statements ('if', 'for',
  'switch',
  # 'while', etc.).
  sp_before_sparen                = add      # ignore/add/remove/force
```