### PR TITLE
Fix compiler warning in newer gcc

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -417,7 +417,7 @@ static gboolean feedback_progress(const gchar *url, const gchar *id, gint progre
  */
 static long json_get_sleeptime(JsonNode *root)
 {
-        const gchar *sleeptime_str = json_get_string(root, "$.config.polling.sleep");
+        gchar *sleeptime_str = json_get_string(root, "$.config.polling.sleep");
         if (sleeptime_str) {
                 struct tm time;
                 strptime(sleeptime_str, "%T", &time);


### PR DESCRIPTION
I missed the const, when I reviewed PR #32.
This should remove the compiler warning in newer gcc.