### PR TITLE
Fix autofree of GKeyFile in config-file.c

### DIFF
--- a/src/config-file.c
+++ b/src/config-file.c
@@ -171,7 +171,7 @@ struct config* load_config_file(const gchar* config_file, GError** error)
 
         gint val_int;
         g_autofree gchar *val = NULL;
-        g_autofree GKeyFile *ini_file = g_key_file_new();
+        g_autoptr(GKeyFile) ini_file = g_key_file_new();
         gboolean key_auth_token_exists = FALSE;
         gboolean key_gateway_token_exists = FALSE;
 


### PR DESCRIPTION
GKeyFile is declared with g_autofree which is wrong. This fix use
g_autoptr with auto cleanup function registered for GKeyFile.

How it is related to segfault in #21, I'm not sure.

Fixes #21

Signed-off-by: Lasse K. Mikkelsen <lasse.klok@prevas.dk>