### PR TITLE
Fix free storage space calculation overflowing

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -75,7 +75,7 @@ static long last_run_sec = 0;
  * @param[in] path Path
  * @return If error -1 else free space in bytes
  */
-static long get_available_space(const char* path, GError **error)
+static goffset get_available_space(const char* path, GError **error)
 {
         struct statvfs stat;
         g_autofree gchar *npath = g_strdup(path);
@@ -85,8 +85,9 @@ static long get_available_space(const char* path, GError **error)
                 g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_FAILED, "Failed to calculate free space: %s", g_strerror(errno));
                 return -1;
         }
+
         // the available free space is f_bsize * f_bavail
-        return stat.f_bsize * stat.f_bavail;
+        return (goffset) stat.f_bsize * (goffset) stat.f_bavail;
 }
 
 /**
@@ -683,14 +684,14 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
                   artifact->name, artifact->version, artifact->size, artifact->download_url);
 
         // Check if there is enough free diskspace
-        long freespace = get_available_space(hawkbit_config->bundle_download_location, &ierror);
+        goffset freespace = get_available_space(hawkbit_config->bundle_download_location, &ierror);
         if (freespace == -1) {
                 feedback(feedback_url, action_id, ierror->message, "failure", "closed", NULL);
                 g_propagate_error(error, ierror);
                 status = -4;
                 goto proc_error;
         } else if (freespace < artifact->size) {
-                g_autofree gchar *msg = g_strdup_printf("Not enough free space. File size: %" G_GINT64_FORMAT  ". Free space: %ld",
+                g_autofree gchar *msg = g_strdup_printf("Not enough free space. File size: %" G_GINT64_FORMAT  ". Free space: %" G_GOFFSET_FORMAT,
                                                         artifact->size, freespace);
                 g_debug("%s", msg);
                 // Notify hawkbit that there is not enough free space.


### PR DESCRIPTION
The number of available bytes of storage calculated can overflow when there is too much free space.

On a machine where long is only 32 bits in size the overflow occurs with more than about 2 GB available.
The `get_available_space()` function then reports a negative value and the rollout fails with "Not enough free space" e.g..
`Error: Not enough free space. File size: 71264324. Free space: -94932992`
