### PR TITLE
Clean up includes

### DIFF
--- a/include/config-file.h
+++ b/include/config-file.h
@@ -22,9 +22,7 @@
 #ifndef __CONFIG_FILE_H__
 #define __CONFIG_FILE_H__
 
-#include <stdlib.h>
 #include <glib.h>
-#include <glib/gprintf.h>
 
 /**
  * @brief struct that contains the Rauc HawkBit configuration.

--- a/include/config-file.h
+++ b/include/config-file.h
@@ -23,7 +23,7 @@
 #define __CONFIG_FILE_H__
 
 #include <stdlib.h>
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include <glib/gprintf.h>
 
 /**

--- a/include/hawkbit-client.h
+++ b/include/hawkbit-client.h
@@ -22,7 +22,10 @@
 #ifndef __HAWKBIT_CLIENT_H__
 #define __HAWKBIT_CLIENT_H__
 
-#include "config-file.h"
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <stdio.h>
+struct config;
 
 #define HAWKBIT_USERAGENT                 "rauc-hawkbit-c-agent/1.0"
 #define DEFAULT_CURL_REQUEST_BUFFER_SIZE  512

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -23,6 +23,7 @@
 #define __JSON_HELPER_H__
 
 #include <glib.h>
+#include <glib/gtypes.h>
 #include <json-glib/json-glib.h>
 
 gchar* json_get_string(JsonNode *json_node, const gchar *path);

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -22,7 +22,7 @@
 #ifndef __JSON_HELPER_H__
 #define __JSON_HELPER_H__
 
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include <json-glib/json-glib.h>
 
 gchar* json_get_string(JsonNode *json_node, const gchar *path);

--- a/include/log.h
+++ b/include/log.h
@@ -22,7 +22,7 @@
 #ifndef __LOG_H__
 #define __LOG_H__
 
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include <syslog.h>
 #ifdef WITH_SYSTEMD
 #include <systemd/sd-journal.h>

--- a/include/log.h
+++ b/include/log.h
@@ -23,7 +23,6 @@
 #define __LOG_H__
 
 #include <glib.h>
-#include <syslog.h>
 #ifdef WITH_SYSTEMD
 #include <systemd/sd-journal.h>
 #endif

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -22,7 +22,6 @@
 #ifndef __RAUC_INSTALLER_H__
 #define __RAUC_INSTALLER_H__
 
-#include <stdbool.h>
 #include <stdio.h>
 #include <glib-2.0/glib.h>
 #include "rauc-installer-gen.h"

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -22,9 +22,7 @@
 #ifndef __RAUC_INSTALLER_H__
 #define __RAUC_INSTALLER_H__
 
-#include <stdio.h>
 #include <glib.h>
-#include "rauc-installer-gen.h"
 
 /**
  * @brief struct that contains the context of an Rauc installation.

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -23,7 +23,7 @@
 #define __RAUC_INSTALLER_H__
 
 #include <stdio.h>
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include "rauc-installer-gen.h"
 
 /**

--- a/include/sd-helper.h
+++ b/include/sd-helper.h
@@ -22,7 +22,7 @@
 #ifndef __SD_HELPER_H__
 #define __SD_HELPER_H__
 
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include <systemd/sd-event.h>
 #include <systemd/sd-daemon.h>
 

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -25,6 +25,9 @@
  */
 
 #include "config-file.h"
+#include <glib/gtypes.h>
+#include <stdlib.h>
+
 
 static const gint DEFAULT_CONNECTTIMEOUT  = 20;     // 20 sec.
 static const gint DEFAULT_TIMEOUT         = 60;     // 1 min.

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -44,7 +44,10 @@
 #include <glib/gstdio.h>
 #include <json-glib/json-glib.h>
 #include <libgen.h>
+#include <bits/types/struct_tm.h>
+#include <gio/gio.h>
 
+#include "config-file.h"
 #include "json-helper.h"
 #ifdef WITH_SYSTEMD
 #include "sd-helper.h"

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -39,7 +39,7 @@
 #include <errno.h>
 #include <sys/statvfs.h>
 #include <curl/curl.h>
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include <glib-object.h>
 #include <glib/gstdio.h>
 #include <json-glib/json-glib.h>

--- a/src/json-helper.c
+++ b/src/json-helper.c
@@ -25,6 +25,7 @@
  */
 
 #include "json-helper.h"
+#include <stddef.h>
 
 gchar* json_get_string(JsonNode *json_node, const gchar *path)
 {

--- a/src/log.c
+++ b/src/log.c
@@ -24,6 +24,7 @@
  */
 
 #include "log.h"
+#include <stddef.h>
 
 static gboolean output_to_systemd = FALSE;
 

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -25,7 +25,6 @@
  */
 
 
-#include <stdbool.h>
 #include <stdio.h>
 #include <glib-2.0/glib.h>
 #include "rauc-installer.h"

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -26,7 +26,7 @@
 
 
 #include <stdio.h>
-#include <glib-2.0/glib.h>
+#include <glib.h>
 #include "rauc-installer.h"
 #include "hawkbit-client.h"
 #include "config-file.h"

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <glib.h>
+#include <glib/gprintf.h>
 #include "rauc-installer.h"
 #include "hawkbit-client.h"
 #include "config-file.h"

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -24,7 +24,14 @@
  *
  */
 
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <glib/gtypes.h>
+#include <stdio.h>
+#include "gobject/gclosure.h"
 #include "rauc-installer.h"
+#include "rauc-installer-gen.h"
+
 
 /**
  * @brief RAUC DBUS property changed callback


### PR DESCRIPTION
This is a manual cleanup of includes supported by the clang tool 'include-what-you-use'.

This also fixes #41 now.

The reports were generated with

``` sh
mdkir build
cd build/
cmake -DCMAKE_C_INCLUDE_WHAT_YOU_USE="iwyu" ..
make
```