### PR TITLE
.gitignore: Ignore Add uncrustify temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ include/*-gen.h
 include/*.gch
 # build
 build/
+
+# Backup files done by uncrustify
+.uncrustify/
+*~


### PR DESCRIPTION
uncrustify leftovers are not ignored. This commit update  .gitignore to discard such files from being staged by mistake. 

This PR closes #57 