### PR TITLE
json-helper: documentation, refactoring and bug fixes

### DIFF
--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -45,7 +45,17 @@ gchar* json_get_string(JsonNode *json_node, const gchar *path, GError **error);
  * @return gint64, integer value, 0 on error (error set)
  */
 gint64 json_get_int(JsonNode *json_node, const gchar *path, GError **error);
-JsonArray* json_get_array(JsonNode *json_node, const gchar *path);
+
+/**
+ * @brief Get the JsonArray inside the first JsonNode element matching path in json_node.
+ *
+ * @param[in]  json_node JsonNode to evaluate expression on
+ * @param[in]  path      JSONPath expression
+ * @param[out] error     Error
+ * @return JsonArray*, array (must be freed), NULL on error (error set)
+ */
+JsonArray* json_get_array(JsonNode *json_node, const gchar *path, GError **error);
+
 gboolean json_contains(JsonNode *root, gchar *key);
 
 #endif // __JSON_HELPER_H__

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -26,7 +26,15 @@
 #include <glib/gtypes.h>
 #include <json-glib/json-glib.h>
 
-gchar* json_get_string(JsonNode *json_node, const gchar *path);
+/**
+ * @brief Get the string inside the first JsonNode element matching path in json_node.
+ *
+ * @param[in]  json_node JsonNode to evaluate expression on
+ * @param[in]  path      JSONPath expression
+ * @param[out] error     Error
+ * @return gchar*, string value (must be freed), NULL on error (error set)
+ */
+gchar* json_get_string(JsonNode *json_node, const gchar *path, GError **error);
 gint64 json_get_int(JsonNode *json_node, const gchar *path);
 JsonArray* json_get_array(JsonNode *json_node, const gchar *path);
 gboolean json_contains(JsonNode *root, gchar *key);

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -56,6 +56,13 @@ gint64 json_get_int(JsonNode *json_node, const gchar *path, GError **error);
  */
 JsonArray* json_get_array(JsonNode *json_node, const gchar *path, GError **error);
 
+/**
+ * @brief Check if the given path matches an element in json_node.
+ *
+ * @param[in] json_node JsonNode to evaluate expression on
+ * @param[in] path      JSONPath expression
+ * @return gboolean, TRUE if path matches an element, FALSE otherwise
+ */
 gboolean json_contains(JsonNode *root, gchar *key);
 
 #endif // __JSON_HELPER_H__

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -35,7 +35,16 @@
  * @return gchar*, string value (must be freed), NULL on error (error set)
  */
 gchar* json_get_string(JsonNode *json_node, const gchar *path, GError **error);
-gint64 json_get_int(JsonNode *json_node, const gchar *path);
+
+/**
+ * @brief Get the integer inside the first JsonNode element matching path in json_node.
+ *
+ * @param[in]  json_node JsonNode to evaluate expression on
+ * @param[in]  path      JSONPath expression
+ * @param[out] error     Error
+ * @return gint64, integer value, 0 on error (error set)
+ */
+gint64 json_get_int(JsonNode *json_node, const gchar *path, GError **error);
 JsonArray* json_get_array(JsonNode *json_node, const gchar *path);
 gboolean json_contains(JsonNode *root, gchar *key);
 

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -430,7 +430,7 @@ static long json_get_sleeptime(JsonNode *root)
         struct tm time;
         long poll_sleep_time;
 
-        sleeptime_str = json_get_string(root, "$.config.polling.sleep");
+        sleeptime_str = json_get_string(root, "$.config.polling.sleep", NULL);
         if (!sleeptime_str) {
                 poll_sleep_time = hawkbit_config->retry_wait;
                 goto out;
@@ -628,7 +628,7 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
         }
 
         // get deployment url
-        g_autofree gchar *deployment = json_get_string(req_root, "$._links.deploymentBase.href");
+        g_autofree gchar *deployment = json_get_string(req_root, "$._links.deploymentBase.href", NULL);
         if (deployment == NULL) {
                 g_set_error(error,1,1,"Failed to parse deployment base response.");
                 return FALSE;
@@ -680,16 +680,16 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
 
         // get artifact information
         artifact = g_new0(struct artifact, 1);
-        artifact->version = json_get_string(json_chunk, "$.version");
-        artifact->name = json_get_string(json_chunk, "$.name");
+        artifact->version = json_get_string(json_chunk, "$.version", NULL);
+        artifact->name = json_get_string(json_chunk, "$.name", NULL);
         artifact->size = json_get_int(json_artifact, "$.size");
-        artifact->sha1 = json_get_string(json_artifact, "$.hashes.sha1");
-        artifact->md5 = json_get_string(json_artifact, "$.hashes.md5");
+        artifact->sha1 = json_get_string(json_artifact, "$.hashes.sha1", NULL);
+        artifact->md5 = json_get_string(json_artifact, "$.hashes.md5", NULL);
         artifact->feedback_url = feedback_url;
         // favour https download
-        artifact->download_url = json_get_string(json_artifact, "$._links.download.href");
+        artifact->download_url = json_get_string(json_artifact, "$._links.download.href", NULL);
         if (artifact->download_url == NULL)
-                artifact->download_url = json_get_string(json_artifact, "$._links.download-http.href");
+                artifact->download_url = json_get_string(json_artifact, "$._links.download-http.href", NULL);
 
         if (artifact->download_url == NULL) {
                 feedback(feedback_url, action_id, "Failed to parse deployment resource.", "failure", "closed", NULL);

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -682,7 +682,7 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
         artifact = g_new0(struct artifact, 1);
         artifact->version = json_get_string(json_chunk, "$.version", NULL);
         artifact->name = json_get_string(json_chunk, "$.name", NULL);
-        artifact->size = json_get_int(json_artifact, "$.size");
+        artifact->size = json_get_int(json_artifact, "$.size", NULL);
         artifact->sha1 = json_get_string(json_artifact, "$.hashes.sha1", NULL);
         artifact->md5 = json_get_string(json_artifact, "$.hashes.md5", NULL);
         artifact->feedback_url = feedback_url;

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -661,7 +661,7 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
         }
         JsonNode *resp_root = json_parser_get_root(json_response_parser);
 
-        JsonArray *json_chunks = json_get_array(resp_root, "$.deployment.chunks");
+        JsonArray *json_chunks = json_get_array(resp_root, "$.deployment.chunks", NULL);
         if (json_chunks == NULL || json_array_get_length(json_chunks) == 0) {
                 feedback(feedback_url, action_id, "Failed to parse deployment resource.", "failure", "closed", NULL);
                 g_set_error(error,1,20,"Failed to parse deployment resource.");
@@ -670,7 +670,7 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
 
         // Downloading multiple chunks not supported. Only first chunk is downloaded (RAUC bundle)
         JsonNode *json_chunk = json_array_get_element(json_chunks, 0);
-        JsonArray *json_artifacts = json_get_array(json_chunk, "$.artifacts");
+        JsonArray *json_artifacts = json_get_array(json_chunk, "$.artifacts", NULL);
         if (json_artifacts == NULL || json_array_get_length(json_artifacts) == 0) {
                 feedback(feedback_url, action_id, "Failed to parse deployment resource.", "failure", "closed", NULL);
                 g_set_error(error,1,21,"Failed to parse deployment resource.");

--- a/src/json-helper.c
+++ b/src/json-helper.c
@@ -142,10 +142,23 @@ JsonArray* json_get_array(JsonNode *json_node, const gchar *path, GError **error
         return g_steal_pointer(&res_arr);
 }
 
-gboolean json_contains(JsonNode *root, gchar *key)
+gboolean json_contains(JsonNode *json_node, gchar *path)
 {
-        JsonNode *node = json_path_query(key, root, NULL);
-        gboolean result = (node != NULL && json_array_get_length(json_node_get_array(node)) > 0);
-        json_node_unref(node);
-        return result;
+        g_autoptr(GError) error = NULL;
+        g_autoptr(JsonNode) node = NULL;
+
+        g_return_val_if_fail(json_node, FALSE);
+        g_return_val_if_fail(path, FALSE);
+
+        node = json_path_query(path, json_node, &error);
+        if (!node) {
+                // failed to compile expression to JSONPath
+                g_warning("%s", error->message);
+                return FALSE;
+        }
+
+        if (json_array_get_length(json_node_get_array(node)) > 0)
+                return TRUE;
+
+        return FALSE;
 }


### PR DESCRIPTION
This is the first of a series of PRs to refactor and clean up the code base, get rid of bugs (memory leaks, use-after-frees, race conditions), simplify functions and document them.

In this iteration I focused on the `json-helper` module (which required some minor changes in `hawkbit-client`).