### PR TITLE
sd-helper: minor refactoring

### DIFF
--- a/include/sd-helper.h
+++ b/include/sd-helper.h
@@ -41,7 +41,7 @@ struct SDSource
  *
  * @param[in] source Glib GSource
  * @param[in] loop GMainLoop the GSource should be attached to.
- * @return 0 if success else != 0 if error
+ * @return 0 on success, value != 0 on error
  * @see https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#GMainLoop
  * @see https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#GSource
  */
@@ -51,10 +51,12 @@ int sd_source_attach(GSource *source, GMainLoop *loop);
  * @brief Create GSource from a sd_event
  *
  * @param[in] event Systemd event that should be converted to a Glib GSource
- * @return GSource
+ * @return the newly-created GSource
  * @see https://www.freedesktop.org/software/systemd/man/sd-event.html
  * @see https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#GSource
  */
 GSource * sd_source_new(sd_event *event);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(sd_event, sd_event_unref)
 
 #endif // __SD_HELPER_H__


### PR DESCRIPTION
This is the second of a series of PRs to refactor and clean up the code base, get rid of bugs (memory leaks, use-after-frees, race conditions), simplify functions and document them.

Clean and improve functions:
- update documentation
- separate variable declaration and code
- sanity check input arguments
- wrap long lines