### PR TITLE
config-file: documentation, refactoring and bug fixes

### DIFF
--- a/include/config-file.h
+++ b/include/config-file.h
@@ -36,13 +36,20 @@ typedef struct Config_ {
         gchar* tenant_id;                 /**< hawkBit tenant id */
         gchar* controller_id;             /**< hawkBit controller id*/
         gchar* bundle_download_location;  /**< file to download rauc bundle to */
-        long connect_timeout;             /**< connection timeout */
-        long timeout;                     /**< reply timeout */
+        int connect_timeout;              /**< connection timeout */
+        int timeout;                      /**< reply timeout */
         int retry_wait;                   /**< wait between retries */
         GLogLevelFlags log_level;         /**< log level */
         GHashTable* device;               /**< Additional attributes sent to hawkBit */
 } Config;
 
+/**
+ * @brief Get Config for config_file.
+ *
+ * @param[in]  config_file String value containing path to config file
+ * @param[out] error       Error
+ * @return Config on success, NULL otherwise (error is set)
+ */
 Config* load_config_file(const gchar *config_file, GError **error);
 
 /**

--- a/include/config-file.h
+++ b/include/config-file.h
@@ -27,7 +27,7 @@
 /**
  * @brief struct that contains the Rauc HawkBit configuration.
  */
-struct config {
+typedef struct Config_ {
         gchar* hawkbit_server;            /**< hawkBit host or IP and port */
         gboolean ssl;                     /**< use https or http */
         gboolean ssl_verify;              /**< verify https certificate */
@@ -41,9 +41,17 @@ struct config {
         int retry_wait;                   /**< wait between retries */
         GLogLevelFlags log_level;         /**< log level */
         GHashTable* device;               /**< Additional attributes sent to hawkBit */
-};
+} Config;
 
-struct config* load_config_file(const gchar* config_file, GError** error);
-void config_file_free(struct config *config);
+Config* load_config_file(const gchar *config_file, GError **error);
+
+/**
+ * @brief Frees the memory allocated by a Config
+ *
+ * @param[in] config Config to free
+ */
+void config_file_free(Config *config);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(Config, config_file_free)
 
 #endif // __CONFIG_FILE_H__

--- a/include/hawkbit-client.h
+++ b/include/hawkbit-client.h
@@ -25,7 +25,8 @@
 #include <glib.h>
 #include <glib/gtypes.h>
 #include <stdio.h>
-struct config;
+
+#include "config-file.h"
 
 #define HAWKBIT_USERAGENT                 "rauc-hawkbit-c-agent/1.0"
 #define DEFAULT_CURL_REQUEST_BUFFER_SIZE  512
@@ -100,7 +101,7 @@ struct on_install_complete_userdata {
         gboolean install_success;               /**< status of installation */
 };
 
-void hawkbit_init(struct config *config, GSourceFunc on_install_ready);
+void hawkbit_init(Config *config, GSourceFunc on_install_ready);
 int hawkbit_start_service_sync();
 gboolean hawkbit_progress(const gchar *msg);
 gboolean install_complete_cb(gpointer ptr);

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -36,17 +36,6 @@ static const gboolean DEFAULT_SSL         = TRUE;
 static const gboolean DEFAULT_SSL_VERIFY  = TRUE;
 static const gchar * DEFAULT_LOG_LEVEL    = "message";
 
-void config_file_free(struct config *config)
-{
-        g_free(config->hawkbit_server);
-        g_free(config->controller_id);
-        g_free(config->tenant_id);
-        g_free(config->auth_token);
-        g_free(config->gateway_token);
-        g_free(config->bundle_download_location);
-        g_hash_table_destroy(config->device);
-}
-
 static gboolean get_key_string(GKeyFile *key_file, const gchar* group, const gchar* key, gchar** value, const gchar* default_value, GError **error)
 {
         gchar *val = NULL;
@@ -168,9 +157,9 @@ static GLogLevelFlags log_level_from_string(const gchar *log_level)
         }
 }
 
-struct config* load_config_file(const gchar* config_file, GError** error)
+Config* load_config_file(const gchar* config_file, GError** error)
 {
-        struct config *config = g_new0(struct config, 1);
+        Config *config = g_new0(Config, 1);
 
         gint val_int;
         g_autofree gchar *val = NULL;
@@ -235,4 +224,20 @@ struct config* load_config_file(const gchar* config_file, GError** error)
         }
 
         return config;
+}
+
+void config_file_free(Config *config)
+{
+        if (!config)
+                return;
+
+        g_free(config->hawkbit_server);
+        g_free(config->controller_id);
+        g_free(config->tenant_id);
+        g_free(config->auth_token);
+        g_free(config->gateway_token);
+        g_free(config->bundle_download_location);
+        if (config->device)
+                g_hash_table_destroy(config->device);
+        g_free(config);
 }

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -276,7 +276,9 @@ Config* load_config_file(const gchar *config_file, GError **error)
                 return NULL;
         }
         if (key_auth_token_exists && key_gateway_token_exists) {
-                g_warning("Both auth_token and gateway_token are set in the config.");
+                g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
+                            "Both auth_token and gateway_token are set in the config.");
+                return NULL;
         }
 
         if (!get_key_string(ini_file, "client", "target_name", &config->controller_id, NULL,

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -210,8 +210,16 @@ static gboolean get_group(GKeyFile *key_file, const gchar *group, GHashTable **h
         return TRUE;
 }
 
+/**
+ * @brief Get GLogLevelFlags for error string.
+ *
+ * @param[in]  log_level Log level string
+ * @return GLogLevelFlags matching error string, else default log level (message)
+ */
 static GLogLevelFlags log_level_from_string(const gchar *log_level)
 {
+        g_return_val_if_fail(log_level, 0);
+
         if (g_strcmp0(log_level, "error") == 0) {
                 return G_LOG_LEVEL_ERROR;
         } else if (g_strcmp0(log_level, "critical") == 0) {
@@ -227,8 +235,11 @@ static GLogLevelFlags log_level_from_string(const gchar *log_level)
                        G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE |
                        G_LOG_LEVEL_INFO;
         } else if (g_strcmp0(log_level, "debug") == 0) {
-                return G_LOG_LEVEL_MASK;
+                return G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL |
+                       G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE |
+                       G_LOG_LEVEL_INFO | G_LOG_LEVEL_DEBUG;
         } else {
+                g_warning("Invalid log level given, defaulting to level \"message\"");
                 return G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL |
                        G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE;
         }

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -55,21 +55,44 @@ static gboolean get_key_string(GKeyFile *key_file, const gchar* group, const gch
         return TRUE;
 }
 
-static gboolean get_key_bool(GKeyFile *key_file, const gchar* group, const gchar* key, gboolean* value, const gboolean default_value, GError **error)
+/**
+ * @brief Get gboolean value from key_file for key in group, default_value must be specified,
+ * returned in case key not found in group.
+ *
+ * @param[in]  key_file      GKeyFile to look value up
+ * @param[in]  group         A group name
+ * @param[in]  key           A key
+ * @param[out] value         Output gboolean value
+ * @param[in]  default_value Return this value in case no value found
+ * @param[out] error         Error
+ * @return FALSE on error (error is set), TRUE otherwise. Note that TRUE is returned if key in
+ *         group is not found, value is set to default_value in this case.
+ */
+static gboolean get_key_bool(GKeyFile *key_file, const gchar *group, const gchar *key,
+                             gboolean *value, const gboolean default_value, GError **error)
 {
         g_autofree gchar *val = NULL;
+
+        g_return_val_if_fail(key_file, FALSE);
+        g_return_val_if_fail(group, FALSE);
+        g_return_val_if_fail(key, FALSE);
+        g_return_val_if_fail(value, FALSE);
+        g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
         val = g_key_file_get_string(key_file, group, key, NULL);
-        if (val == NULL) {
+        if (!val) {
                 *value = default_value;
                 return TRUE;
         }
-        gboolean val_false = (g_strcmp0(val, "0") == 0 || g_ascii_strcasecmp(val, "no") == 0 || g_ascii_strcasecmp(val, "false") == 0);
-        if (val_false) {
+
+        if (g_strcmp0(val, "0") == 0 || g_ascii_strcasecmp(val, "no") == 0 ||
+            g_ascii_strcasecmp(val, "false") == 0) {
                 *value = FALSE;
                 return TRUE;
         }
-        gboolean val_true = (g_strcmp0(val, "1") == 0 || g_ascii_strcasecmp(val, "yes") == 0 || g_ascii_strcasecmp(val, "true") == 0);
-        if (val_true) {
+
+        if (g_strcmp0(val, "1") == 0 || g_ascii_strcasecmp(val, "yes") == 0 ||
+            g_ascii_strcasecmp(val, "true") == 0) {
                 *value = TRUE;
                 return TRUE;
         }

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -124,20 +124,42 @@ static gboolean get_key_bool(GKeyFile *key_file, const gchar *group, const gchar
         return FALSE;
 }
 
-static gboolean get_key_int(GKeyFile *key_file, const gchar* group, const gchar* key, gint* value, const gint default_value, GError **error)
+/**
+ * @brief Get integer value from key_file for key in group, default_value must be specified,
+ * returned in case key not found in group.
+ *
+ * @param[in]  key_file      GKeyFile to look value up
+ * @param[in]  group         A group name
+ * @param[in]  key           A key
+ * @param[out] value         Output integer value
+ * @param[in]  default_value Return this value in case no value found
+ * @param[out] error         Error
+ * @return FALSE on error (error is set), TRUE otherwise. Note that TRUE is returned if key in
+ *         group is not found, value is set to default_value in this case.
+ */
+static gboolean get_key_int(GKeyFile *key_file, const gchar *group, const gchar *key, gint *value,
+                            const gint default_value, GError **error)
 {
         GError *ierror = NULL;
-        gint val = g_key_file_get_integer(key_file, group, key, &ierror);
+        gint val;
 
-        if (val == 0 && g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+        g_return_val_if_fail(key_file, FALSE);
+        g_return_val_if_fail(group, FALSE);
+        g_return_val_if_fail(key, FALSE);
+        g_return_val_if_fail(value, FALSE);
+        g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+        val = g_key_file_get_integer(key_file, group, key, &ierror);
+
+        if (g_error_matches(ierror, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
                 g_clear_error(&ierror);
                 *value = default_value;
                 return TRUE;
-        }
-        else if (val == 0 && ierror) {
+        } else if (ierror) {
                 g_propagate_error(error, ierror);
                 return FALSE;
         }
+
         *value = val;
         return TRUE;
 }

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -47,7 +47,6 @@
 #include <bits/types/struct_tm.h>
 #include <gio/gio.h>
 
-#include "config-file.h"
 #include "json-helper.h"
 #ifdef WITH_SYSTEMD
 #include "sd-helper.h"
@@ -64,7 +63,7 @@ static const char *HTTPMethod_STRING[] = {
         "GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"
 };
 
-static struct config *hawkbit_config = NULL;
+static Config *hawkbit_config = NULL;
 static GSourceFunc software_ready_cb;
 static gchar * volatile action_id = NULL;
 static GThread *thread_download = NULL;
@@ -738,7 +737,7 @@ proc_error:
 }
 
 
-void hawkbit_init(struct config *config, GSourceFunc on_install_ready)
+void hawkbit_init(Config *config, GSourceFunc on_install_ready)
 {
         hawkbit_config = config;
         software_ready_cb = on_install_ready;

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
                 run_once = TRUE;
         }
 
-        struct config *config = load_config_file(config_file, &error);
+        Config *config = load_config_file(config_file, &error);
         if (config == NULL) {
                 g_printerr("Loading config file failed: %s\n", error->message);
                 g_error_free(error);

--- a/test/rauc-hawkbit-updater.t
+++ b/test/rauc-hawkbit-updater.t
@@ -70,10 +70,8 @@ test_expect_success "rauc-hawkbit-updater register and check (both security toke
   $SHARNESS_TEST_DIRECTORY/create_test_target &&
   cp $SHARNESS_TEST_DIRECTORY/test-config-both-security-tokens.conf . &&
   sed -i s/TEST_TOKEN/$INVALID_TOKEN/g test-config-both-security-tokens.conf &&
-  echo '\n** (rauc-hawkbit-updater:3783): WARNING **: 18:00:55.091: Both auth_token and gateway_token are set in the config.\nMESSAGE: Checking for new software...\nCRITICAL: Failed to authenticate. Check if auth_token is correct?' \
-    | sed 's#^\\*\\* \(.*\): WARNING \\*\\*:\( .*:\)\?#\\*\\* \(\): WARNING \\*\\*: :#' > expected_out &&
-  test_expect_code 1 rauc-hawkbit-updater -r -c $SHARNESS_TEST_DIRECTORY/test-config-both-security-tokens.conf 2>&1 \
-    | sed 's#^\\*\\* \(.*\): WARNING \\*\\*:\( .*:\)\?#\\*\\* \(\): WARNING \\*\\*: :#' > actual_out &&
+  echo 'Loading config file failed: Both auth_token and gateway_token are set in the config.' > expected_out &&
+  test_expect_code 4 rauc-hawkbit-updater -r -c $SHARNESS_TEST_DIRECTORY/test-config-both-security-tokens.conf > actual_out 2>&1 &&
   test_cmp expected_out actual_out
 "
 


### PR DESCRIPTION
This is the third of a series of PRs to refactor and clean up the code base, get rid of bugs (memory leaks, use-after-frees, race conditions), simplify functions and document them.

In this iteration I focused on the `config-file` module (which required some minor changes in `hawkbit-client`).