### PR TITLE
rauc-installer: refactoring and bug fixes

### DIFF
--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -42,9 +42,12 @@ struct install_context {
  * @brief RAUC install bundle
  *
  * @param[in] bundle RAUC bundle file (.raucb) to install.
- * @param[in] on_install_notify Callback function to be called with status info during installation.
- * @param[in] on_install_complete Callback function to be called with the result of the installation.
+ * @param[in] on_install_notify Callback function to be called with status info during
+ *                              installation.
+ * @param[in] on_install_complete Callback function to be called with the result of the
+ *                                installation.
  */
-void rauc_install(const gchar *bundle, GSourceFunc on_install_notify, GSourceFunc on_install_complete);
+void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
+                GSourceFunc on_install_complete);
 
 #endif // __RAUC_INSTALLER_H__

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -85,20 +85,20 @@ static void on_installer_status(GDBusProxy *proxy, GVariant *changed,
 /**
  * @brief RAUC DBUS complete signal callback
  *
- * @see https://github.com/rauc/rauc/blob/master/src/rauc-installer.xml
+ * @see https://github.com/rauc/rauc/blob/master/src/de.pengutronix.rauc.Installer.xml
  */
-static void on_installer_completed(GDBusProxy *proxy, gint result,
-                                   gpointer data)
+static void on_installer_completed(GDBusProxy *proxy, gint result, gpointer data)
 {
         struct install_context *context = data;
+
+        g_return_if_fail(context);
 
         g_mutex_lock(&context->status_mutex);
         context->status_result = result;
         g_mutex_unlock(&context->status_mutex);
 
-        if (result >= 0) {
+        if (result >= 0)
                 g_main_loop_quit(context->mainloop);
-        }
 }
 
 /**

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -199,18 +199,15 @@ notify_complete:
         return NULL;
 }
 
-/**
- * @brief RAUC install bundle
- *
- * @param[in] bundle RAUC bundle file (.raucb) to install.
- * @param[in] on_install_notify Callback function to be called with status info during installation.
- * @param[in] on_install_complete Callback function to be called with the result of the installation.
- */
-void rauc_install(const gchar *bundle, GSourceFunc on_install_notify, GSourceFunc on_install_complete)
+void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
+                  GSourceFunc on_install_complete)
 {
-        GMainContext *loop_context = g_main_context_new();
-        struct install_context *context;
+        GMainContext *loop_context = NULL;
+        struct install_context *context = NULL;
 
+        g_return_if_fail(bundle);
+
+        loop_context = g_main_context_new();
         context = install_context_new();
         context->bundle = g_strdup(bundle);
         context->notify_event = on_install_notify;
@@ -224,6 +221,5 @@ void rauc_install(const gchar *bundle, GSourceFunc on_install_notify, GSourceFun
                 g_thread_join(thread_install);
 
         // start install thread
-        thread_install = g_thread_new("installer", install_loop_thread,
-                                      (gpointer) context);
+        thread_install = g_thread_new("installer", install_loop_thread, (gpointer) context);
 }

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -126,8 +126,9 @@ static struct install_context *install_context_new(void)
  */
 static void install_context_free(struct install_context *context)
 {
-        if (context == NULL)
+        if (!context)
                 return;
+
         g_free(context->bundle);
         g_mutex_clear(&context->status_mutex);
         g_main_context_unref(context->loop_context);


### PR DESCRIPTION
This is the fourth of a series of PRs to refactor and clean up the code base, get rid of bugs (memory leaks, use-after-frees, race conditions), simplify functions and document them.

In this iteration I focused on the `rauc-installer` module.