### PR TITLE
.github: tests: use secrets for docker login only for master builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Login to DockerHub
       uses: docker/login-action@v1
+      if: github.ref == 'refs/heads/master'
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Since PR builds from forks do not have access to the GitHub repositories
secrets, a PR will fail logging in to docker:

```
Run docker/login-action@v1
  with:
    logout: true
Error: Username and password required
```

Fix this by limiting the use of login-action@v1 to master branch.