### PR TITLE
README: use GitHub Actions badge instead of TravisCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RAUC hawkBit Updater
 ====================
 
-[![Build Status](https://travis-ci.com/rauc/rauc-hawkbit-updater.svg?branch=master)](https://travis-ci.com/rauc/rauc-hawkbit-updater)
+[![Build Status](https://github.com/rauc/rauc-hawkbit-updater/workflows/tests/badge.svg)](https://github.com/rauc/rauc-hawkbit-updater/actions)
 [![License](https://img.shields.io/badge/license-LGPLv2.1-blue.svg)](https://raw.githubusercontent.com/rauc/rauc-hawkbit-updater/master/LICENSE)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/rauc/rauc-hawkbit-updater.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rauc/rauc-hawkbit-updater/alerts/)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/rauc/rauc-hawkbit-updater.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rauc/rauc-hawkbit-updater/context:cpp)


### PR DESCRIPTION
Since 5f366cf5 (".travis.yml: drop, in favor of GitHub actions"), PR #69, GitHub Actions is used instead of TravisCI.