### PR TITLE
.github: tests: run apt-get update before install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Install required packages
       run: |
+        sudo apt-get update
         sudo apt-get install libcurl4-openssl-dev libsystemd-dev libjson-glib-dev
 
     - name: Login to DockerHub


### PR DESCRIPTION
Otherwise, we could end up with a deprecated package cache and fail to install packages not downloadable anymore.