### PR TITLE
test: create_test_target: enable target security token authentication via MGMT API

### DIFF
--- a/test/create_test_target
+++ b/test/create_test_target
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
-# Uses hawkBit MGMT REST API to create a target with a defined security token:
+# Uses hawkBit MGMT REST API to enable target security token authentication and
+# to create a target with a defined security token:
 #
 # [{
 #   "controllerId":"test-controller",
@@ -11,6 +12,12 @@
 
 HAWKBIT_SERVER="localhost:8080"
 HAWKBIT_SERVER_LOGIN="admin:admin"
+
+curl "http://${HAWKBIT_SERVER}/rest/v1/system/configs/authentication.targettoken.enabled" \
+	-u ${HAWKBIT_SERVER_LOGIN} \
+	-X PUT \
+	-H "Content-Type: application/json;charset=UTF-8" -i \
+	-d '{"value" : true}'
 
 curl "http://${HAWKBIT_SERVER}/rest/v1/targets" \
 	-u ${HAWKBIT_SERVER_LOGIN} \


### PR DESCRIPTION
hawkBit's default of "authentication.targettoken.enabled" changed from true to false:

  https://github.com/eclipse/hawkbit/pull/1074

Enable the config option explicitly to make our tests work again.