### PR TITLE
Make critical messages fatal, add useful compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set(RAUC_HAWKBIT_SRCS
 add_executable( rauc-hawkbit-updater ${RAUC_HAWKBIT_SRCS} )
 target_compile_options(rauc-hawkbit-updater PUBLIC -Wall -Wformat-nonliteral)
 if (QA_BUILD)
-  target_compile_options(rauc-hawkbit-updater PUBLIC -Werror -pedantic)
+  target_compile_options(rauc-hawkbit-updater PUBLIC -Wextra -Werror -pedantic -Wbad-function-cast -Wcast-align -Wdeclaration-after-statement -Wformat=2 -Wshadow -Wno-unused-parameter -Wno-missing-field-initializers)
 endif (QA_BUILD)
 
 target_link_libraries( rauc-hawkbit-updater LINK_PUBLIC ${GIO_LIBRARIES}

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -134,6 +134,11 @@ int main(int argc, char **argv)
         g_auto(GStrv) args = NULL;
         GLogLevelFlags log_level;
         g_autoptr(Config) config = NULL;
+        GLogLevelFlags fatal_mask;
+
+        fatal_mask = g_log_set_always_fatal(G_LOG_FATAL_MASK);
+        fatal_mask |= G_LOG_LEVEL_CRITICAL;
+        g_log_set_always_fatal(fatal_mask);
 
         args = g_strdupv(argv);
 


### PR DESCRIPTION
This is the final PR of a series of refactoring PRs (#63, #64, #65, #66, #68, #71, #77). This makes sure we keep up the newly gained code quality via critical messages being turned fatal and a set of compiler warnings.