### PR TITLE
test preparations: make threads wait for each other on --run-once, propagate results

### DIFF
--- a/include/hawkbit-client.h
+++ b/include/hawkbit-client.h
@@ -108,6 +108,7 @@ struct on_new_software_userdata {
         GSourceFunc install_progress_callback;  /**< callback function to be called when new progress */
         GSourceFunc install_complete_callback;  /**< callback function to be called when installation is complete */
         gchar *file;                            /**< downloaded new software file */
+        gboolean install_success;               /**< whether the installation succeeded or not (only meaningful for run_once mode!) */
 };
 
 /**

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -46,8 +46,9 @@ struct install_context {
  *                              installation.
  * @param[in] on_install_complete Callback function to be called with the result of the
  *                                installation.
+ * @param[in] wait Whether to wait until install thread finished or not.
  */
 void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
-                GSourceFunc on_install_complete);
+                GSourceFunc on_install_complete, gboolean wait);
 
 #endif // __RAUC_INSTALLER_H__

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -47,8 +47,10 @@ struct install_context {
  * @param[in] on_install_complete Callback function to be called with the result of the
  *                                installation.
  * @param[in] wait Whether to wait until install thread finished or not.
+ * @return for wait=TRUE, TRUE if installation succeeded, FALSE otherwise; for
+ *         wait=FALSE TRUE is always returned immediately
  */
-void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
+gboolean rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
                 GSourceFunc on_install_complete, gboolean wait);
 
 #endif // __RAUC_INSTALLER_H__

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1040,7 +1040,7 @@ out:
                         res = GPOINTER_TO_INT(thread_ret);
                 }
 
-                data->res = res ? 0 : 1;
+                data->res = res;
                 g_main_loop_quit(data->loop);
                 return G_SOURCE_REMOVE;
         }
@@ -1097,7 +1097,7 @@ int hawkbit_start_service_sync()
 
         g_main_loop_run(cdata.loop);
 
-        res = cdata.res;
+        res = cdata.res ? 0 : 1;
 
 #ifdef WITH_SYSTEMD
         sd_notify(0, "STOPPING=1\nSTATUS=Stopped polling HawkBit for new software.");

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -741,7 +741,10 @@ gboolean install_complete_cb(gpointer ptr)
  * feedback and call software_ready_cb() callback on success.
  *
  * @param[in] data Artifact* to process
- * @return NULL is always returned
+ * @return gpointer being 1 (TRUE) if download succeeded, 0 (FALSE) otherwise. The return value is
+ *         meant to be used with the GPOINTER_TO_INT() macro only.
+ *         Note that if the download thread waited for installation to finish ('run_once' mode),
+ *         TRUE means both installation and download succeeded.
  */
 static gpointer download_thread(gpointer data)
 {
@@ -796,7 +799,7 @@ static gpointer download_thread(gpointer data)
 
         software_ready_cb(&userdata);
 
-        return NULL;
+        return GINT_TO_POINTER(userdata.install_success);
 
 report_err:
         g_mutex_trylock(&active_action->mutex);
@@ -807,7 +810,7 @@ report_err:
         process_deployment_cleanup();
         g_mutex_unlock(&active_action->mutex);
 
-        return NULL;
+        return GINT_TO_POINTER(FALSE);
 }
 
 /**
@@ -1032,8 +1035,10 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
 
 out:
         if (run_once) {
-                if (thread_download)
-                        g_thread_join(thread_download);
+                if (thread_download) {
+                        gpointer thread_ret = g_thread_join(thread_download);
+                        res = GPOINTER_TO_INT(thread_ret);
+                }
 
                 data->res = res ? 0 : 1;
                 g_main_loop_quit(data->loop);

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1032,6 +1032,9 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
 
 out:
         if (run_once) {
+                if (thread_download)
+                        g_thread_join(thread_download);
+
                 data->res = res ? 0 : 1;
                 g_main_loop_quit(data->loop);
                 return G_SOURCE_REMOVE;

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -749,6 +749,7 @@ static gpointer download_thread(gpointer data)
                 .install_progress_callback = (GSourceFunc) hawkbit_progress,
                 .install_complete_callback = install_complete_cb,
                 .file = hawkbit_config->bundle_download_location,
+                .install_success = FALSE,
         };
         g_autoptr(GError) error = NULL, feedback_error = NULL;
         g_autofree gchar *msg = NULL, *sha1sum = NULL;

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -122,7 +122,8 @@ static gboolean on_new_software_ready_cb(gpointer data)
 
         notify_hawkbit_install_progress = userdata->install_progress_callback;
         notify_hawkbit_install_complete = userdata->install_complete_callback;
-        rauc_install(userdata->file, on_rauc_install_progress_cb, on_rauc_install_complete_cb);
+        rauc_install(userdata->file, on_rauc_install_progress_cb, on_rauc_install_complete_cb,
+                     run_once);
 
         return G_SOURCE_REMOVE;
 }

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -122,8 +122,8 @@ static gboolean on_new_software_ready_cb(gpointer data)
 
         notify_hawkbit_install_progress = userdata->install_progress_callback;
         notify_hawkbit_install_complete = userdata->install_complete_callback;
-        rauc_install(userdata->file, on_rauc_install_progress_cb, on_rauc_install_complete_cb,
-                     run_once);
+        userdata->install_success = rauc_install(userdata->file, on_rauc_install_progress_cb,
+                                                 on_rauc_install_complete_cb, run_once);
 
         return G_SOURCE_REMOVE;
 }

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -200,7 +200,7 @@ notify_complete:
 }
 
 void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
-                  GSourceFunc on_install_complete)
+                  GSourceFunc on_install_complete, gboolean wait)
 {
         GMainContext *loop_context = NULL;
         struct install_context *context = NULL;
@@ -222,4 +222,6 @@ void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
 
         // start install thread
         thread_install = g_thread_new("installer", install_loop_thread, (gpointer) context);
+        if (wait)
+                g_thread_join(thread_install);
 }

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -199,13 +199,13 @@ notify_complete:
         return NULL;
 }
 
-void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
-                  GSourceFunc on_install_complete, gboolean wait)
+gboolean rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
+                      GSourceFunc on_install_complete, gboolean wait)
 {
         GMainContext *loop_context = NULL;
         struct install_context *context = NULL;
 
-        g_return_if_fail(bundle);
+        g_return_val_if_fail(bundle, FALSE);
 
         loop_context = g_main_context_new();
         context = install_context_new();
@@ -222,6 +222,11 @@ void rauc_install(const gchar *bundle, GSourceFunc on_install_notify,
 
         // start install thread
         thread_install = g_thread_new("installer", install_loop_thread, (gpointer) context);
-        if (wait)
+        if (wait) {
                 g_thread_join(thread_install);
+                return context->status_result == 0;
+        }
+
+        // return immediately if we did not wait for the install thread
+        return TRUE;
 }


### PR DESCRIPTION
We have a main loop, which starts the download thread if an update is available for the target. The download thread starts the install thread once the download succeeded. Currently the threads do not wait for each other to finish on `-r, --run-once`, but terminate early.

In order to test download and installation cases with `-r, --run-once` and allow use cases such as #73, the threads need to wait for each other to finish. It is also required to emit an appropriate exit code for download and installation errors.

This PR allows the threads to wait for each other to finish on `-r, --run-once` and implements status propagation.