### PR TITLE
Start systemd service after network-online.target

### DIFF
--- a/script/rauc-hawkbit-updater.service
+++ b/script/rauc-hawkbit-updater.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=HawkBit client for Rauc
-After=network.target
-After=rauc.service
+After=network-online.target rauc.service
+Wants=network-online.target
 
 [Service]
 User=rauc-hawkbit


### PR DESCRIPTION
Start the systemd service only after the network is up. If the rauc-hawkbit-updater starts too early without reaching its configured
hawkBit server, network errors occur. Choosing the network-online.target instead of the network.target prevents this.

See also https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/.

In my particular case, I got the following error messages (with debugging options enabled) without this fix:
```
root@hostname:~# journalctl --no-pager -fu rauc-hawkbit-updater
-- Logs begin at Tue 2021-04-27 09:37:12 UTC. --
Apr 27 09:37:14 hostname systemd[1]: Started HawkBit client for Rauc.
Apr 27 09:37:15 hostname rauc-hawkbit-updater[378]: Checking for new software...
Apr 27 09:37:15 hostname rauc-hawkbit-updater[378]: Scheduled check for new software failed status code: 0
Apr 27 09:37:15 hostname rauc-hawkbit-updater[378]: HTTP Error: HTTP request failed: Error
```