### PR TITLE
Clean up source file headers

### DIFF
--- a/include/config-file.h
+++ b/include/config-file.h
@@ -1,23 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
- *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  */
 
 #ifndef __CONFIG_FILE_H__

--- a/include/config-file.h
+++ b/include/config-file.h
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/include/hawkbit-client.h
+++ b/include/hawkbit-client.h
@@ -1,23 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
- *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  */
 
 #ifndef __HAWKBIT_CLIENT_H__

--- a/include/hawkbit-client.h
+++ b/include/hawkbit-client.h
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -1,23 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
- *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  */
 
 #ifndef __JSON_HELPER_H__

--- a/include/json-helper.h
+++ b/include/json-helper.h
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/include/log.h
+++ b/include/log.h
@@ -1,23 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
- *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  */
 
 #ifndef __LOG_H__

--- a/include/log.h
+++ b/include/log.h
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -1,23 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
- *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  */
 
 #ifndef __RAUC_INSTALLER_H__

--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/include/sd-helper.h
+++ b/include/sd-helper.h
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/include/sd-helper.h
+++ b/include/sd-helper.h
@@ -1,23 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
- *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  */
 
 #ifndef __SD_HELPER_H__

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -2,11 +2,8 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file config-file.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date 19 Sep 2018
+ * @file
  * @brief Configuration file parser
- *
  */
 
 #include "config-file.h"

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file config-file.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date 19 Sep 2018

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file hawkbit-client.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date 19 Sep 2018

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -2,12 +2,8 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file hawkbit-client.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date 19 Sep 2018
- * @brief Hawkbit client
- *
- * Implementation of the hawkBit DDI API.
+ * @file
+ * @brief Implementation of the hawkBit DDI API
  *
  * @see https://github.com/rauc/rauc-hawkbit
  * @see https://www.eclipse.org/hawkbit/apis/ddi_api/

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/src/json-helper.c
+++ b/src/json-helper.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file json-helper.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date 19 Sep 2018

--- a/src/json-helper.c
+++ b/src/json-helper.c
@@ -2,11 +2,8 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file json-helper.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date 19 Sep 2018
+ * @file
  * @brief JSON helper functions
- *
  */
 
 #include "json-helper.h"

--- a/src/json-helper.c
+++ b/src/json-helper.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/src/log.c
+++ b/src/log.c
@@ -2,9 +2,7 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file   log.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date   19 Sep 2018
+ * @file
  * @brief  Log handling
  */
 

--- a/src/log.c
+++ b/src/log.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file   log.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date   19 Sep 2018

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -2,13 +2,9 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file rauc-hawkbit-updater.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date 19 Sep 2018
+ * @file
  * @brief RAUC HawkBit updater daemon
- *
  */
-
 
 #include <stdio.h>
 #include <glib.h>

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file rauc-hawkbit-updater.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date 19 Sep 2018

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -2,11 +2,8 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file rauc-installer.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date 19 Sep 2018
+ * @file
  * @brief RAUC client
- *
  */
 
 #include <gio/gio.h>

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file rauc-installer.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date 19 Sep 2018

--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *

--- a/src/sd-helper.c
+++ b/src/sd-helper.c
@@ -2,11 +2,8 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * @file sd-helper.c
- * @author Lasse Mikkelsen <lkmi@prevas.dk>
- * @date 21 Sep 2018
+ * @file
  * @brief Systemd helper
- *
  */
 
 #include "sd-helper.h"

--- a/src/sd-helper.c
+++ b/src/sd-helper.c
@@ -2,22 +2,6 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
- * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
  * @file sd-helper.c
  * @author Lasse Mikkelsen <lkmi@prevas.dk>
  * @date 21 Sep 2018

--- a/src/sd-helper.c
+++ b/src/sd-helper.c
@@ -1,5 +1,6 @@
 /**
  * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-FileCopyrightText: 2018-2020 Lasse K. Mikkelsen <lkmi@prevas.dk>, Prevas A/S (www.prevas.com)
  *
  * Copyright (C) 2018-2020 Prevas A/S (www.prevas.com)
  *


### PR DESCRIPTION
- add `SPDX-FileCopyrightText` to file headers
- drop redundant license headers
- clean up and drop redundant metadata from file headers