### PR TITLE
rauc-installer: fix install_context use-after-free on wait

### DIFF
--- a/include/rauc-installer.h
+++ b/include/rauc-installer.h
@@ -20,6 +20,7 @@ struct install_context {
         gint status_result;           /**< The result of the installation */
         GMainLoop *mainloop;          /**< The installation GMainLoop  */
         GMainContext *loop_context;   /**< GMainContext for the GMainLoop */
+        gboolean keep_install_context; /**< Whether the installation thread should free this struct or keep it */
 };
 
 /**


### PR DESCRIPTION
In "run_once" operation mode, the download thread waits for the install thread to finish. In this case the download thread reads the installation's status result from the install_context struct.

The installation thread frees the install_context before the installation thread reads the status result. Fix that by letting the
installation thread know when to leave the freeing of the install_context struct to the download thread.

Found with address sanitizer (`-fsanitize=address`).

Fixes: 90fcb8db ("rauc-installer: let rauc_install() return result to allow install->download thread propagation")
Fixes #80