### PR TITLE
rauc-installer: process pending events before unreffing loop context

### DIFF
--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -113,7 +113,11 @@ static void install_context_free(struct install_context *context)
 
         g_free(context->bundle);
         g_mutex_clear(&context->status_mutex);
+
+        // make sure all pending events are processed
+        while (g_main_context_iteration(context->loop_context, FALSE));
         g_main_context_unref(context->loop_context);
+
         g_assert_cmpint(context->status_result, >=, 0);
         g_assert_true(g_queue_is_empty(&context->status_messages));
         g_main_loop_unref(context->mainloop);


### PR DESCRIPTION
This fixes memory leaks for these test cases:
- test_install_bundle_no_dbus_iface
- test_install_success (happens sometimes)
- test_install_failure (happens sometimes)

```
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f5eac3a5037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f5eabfebda0 in g_malloc0 (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x57da0)
    #2 0x7f5eac2353e9  (/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0+0x1183e9)
    #3 0x7f5eac2361bb  (/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0+0x1191bb)
    #4 0x7f5eac1978e1 in g_initable_new_valist (/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0+0x7a8e1)
    #5 0x7f5eac197998 in g_initable_new (/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0+0x7a998)
    #6 0x55ba3477d697 in r_installer_proxy_new_for_bus_sync ~someone/rauc-hawkbit-updater/src/rauc-installer-gen.c:1781
    #7 0x55ba3476e918 in install_loop_thread ~someone/rauc-hawkbit-updater/src/rauc-installer.c:145
    #8 0x7f5eac00f0bc  (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x7b0bc)
    #9 0x7f5eabce6ea6 in start_thread nptl/pthread_create.c:477
    #10 0x7f5eabe03dee in __clone (/lib/x86_64-linux-gnu/libc.so.6+0xfddee)
```
See PR #94 introducing the leak sanitizer to our GitHub Actions job.

The problems seems to be that pending events are not processed which leads to memory leaks. Fix that by iterating the loop context until all events are dispatched before decreasing the reference count to zero.

This pattern seems to be rather common:

https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/blob/941629291bb1e2e679f8fbd81b9bc483effdce99/gst-libs/gst/rtsp/gstrtspconnection.c#L2914
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/120e69db60f4ea4501e307c57e04f8fd65fecc3f/tools/gst-launch.c#L1209
https://review.spdk.io/gerrit/plugins/gitiles/spdk/qemu/+/55a2201e79d063766509ed2f2f2e8837b9e1facf/tests/test-aio.c#484