### PR TITLE
rauc-hawkbit-updater: support available locales

### DIFF
--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -7,6 +7,7 @@
  */
 
 #include <stdio.h>
+#include <locale.h>
 #include <glib.h>
 #include <glib/gprintf.h>
 #include "rauc-installer.h"
@@ -121,6 +122,13 @@ int main(int argc, char **argv)
         fatal_mask = g_log_set_always_fatal(G_LOG_FATAL_MASK);
         fatal_mask |= G_LOG_LEVEL_CRITICAL;
         g_log_set_always_fatal(fatal_mask);
+
+        // support available locales and require locale's encoding to be UTF-8
+        setlocale(LC_ALL, "");
+        if (!g_get_charset(NULL)) {
+                g_printerr("Locale's encoding must be UTF-8\n");
+                return 1;
+        }
 
         args = g_strdupv(argv);
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -260,3 +260,13 @@ def rate_limited_port(nginx_proxy):
         return nginx_proxy(location_options)
 
     return _rate_limited_port
+
+@pytest.fixture
+def non_utf8_locale():
+    """Set LC_CTYPE to the C locale. It uses ASCII encoding, not UTF-8."""
+    env = os.environ.copy()
+    os.environ['LC_CTYPE'] = 'C'
+
+    yield
+
+    os.environ = env

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -14,6 +14,13 @@ def test_version():
     assert out.startswith('Version ')
     assert err == ''
 
+def test_invalid_encoding(non_utf8_locale):
+    """Test invalid locale encoding."""
+    out, err, exitcode = run('rauc-hawkbit-updater')
+
+    assert exitcode == 1
+    assert err.strip() == "Locale's encoding must be UTF-8"
+
 def test_invalid_arg():
     """Test invalid argument."""
     out, err, exitcode = run('rauc-hawkbit-updater --invalidarg')


### PR DESCRIPTION
This makes it possible to specify host names containing unicode character in the "hawkbit_server" config option if the system supports it.

Otherwise setting "hawkbit_server" to hüseldösel.de fails with (having CURLOPT_VERBOSE enabled):

```
* Failed to convert hüseldösel.de to ACE; could not convert string to UTF-8
* Closing connection -1
WARNING: Scheduled check for new software failed: URL using bad/illegal format or missing URL (3)
```