### PR TITLE
config-file: remove trailing spaces from string/bool/group option values

### DIFF
--- a/src/config-file.c
+++ b/src/config-file.c
@@ -54,6 +54,7 @@ static gboolean get_key_string(GKeyFile *key_file, const gchar *group, const gch
                 return FALSE;
         }
 
+        val = g_strchomp(val);
         *value = g_steal_pointer(&val);
         return TRUE;
 }
@@ -87,6 +88,8 @@ static gboolean get_key_bool(GKeyFile *key_file, const gchar *group, const gchar
                 *value = default_value;
                 return TRUE;
         }
+
+        val = g_strchomp(val);
 
         if (g_strcmp0(val, "0") == 0 || g_ascii_strcasecmp(val, "no") == 0 ||
             g_ascii_strcasecmp(val, "false") == 0) {
@@ -186,6 +189,7 @@ static gboolean get_group(GKeyFile *key_file, const gchar *group, GHashTable **h
                 if (!value)
                         return FALSE;
 
+                value = g_strchomp(value);
                 g_hash_table_insert(tmp_hash, g_strdup(keys[key]), g_steal_pointer(&value));
         }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -87,7 +87,7 @@ def adjust_config(config):
     adding/overwriting or removing options.
     """
     config_files = []
-    def _adjust_config(options={'client': {}}, remove={}):
+    def _adjust_config(options={'client': {}}, remove={}, add_trailing_space=False):
         adjusted_config = ConfigParser()
         adjusted_config.read(config)
 
@@ -99,6 +99,12 @@ def adjust_config(config):
         # remove
         for section, option in remove.items():
             adjusted_config.remove_option(section, option)
+
+        # add trailing space
+        if add_trailing_space:
+            for orig_section, orig_options in adjusted_config.items():
+                for orig_option in orig_options.items():
+                    adjusted_config.set(orig_section, orig_option[0], orig_option[1] + ' ')
 
         with config.open('w') as f:
             adjusted_config.write(f)

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -4,6 +4,8 @@
 
 from configparser import ConfigParser
 
+import pytest
+
 from helper import run
 
 def test_version():
@@ -73,12 +75,14 @@ def test_register_and_check_invalid_gateway_token(adjust_config):
     assert 'MESSAGE: Checking for new software...' in out
     assert err.strip() == 'WARNING: Failed to authenticate. Check if gateway_token is correct?'
 
-def test_register_and_check_valid_gateway_token(hawkbit, adjust_config):
+@pytest.mark.parametrize("trailing_space", ('no_trailing_space', 'trailing_space'))
+def test_register_and_check_valid_gateway_token(hawkbit, adjust_config, trailing_space):
     """Test config with valid gateway_token."""
     gateway_token = hawkbit.get_config('authentication.gatewaytoken.key')
     config = adjust_config(
             {'client': {'gateway_token': gateway_token}},
-            remove={'client': 'auth_token'}
+            remove={'client': 'auth_token'},
+            add_trailing_space=(trailing_space == 'trailing_space'),
     )
 
     out, err, exitcode = run(f'rauc-hawkbit-updater -c "{config}" -r')
@@ -97,8 +101,12 @@ def test_register_and_check_invalid_auth_token(adjust_config):
     assert 'MESSAGE: Checking for new software...' in out
     assert err.strip() == 'WARNING: Failed to authenticate. Check if auth_token is correct?'
 
-def test_register_and_check_valid_auth_token(config):
+@pytest.mark.parametrize("trailing_space", ('no_trailing_space', 'trailing_space'))
+def test_register_and_check_valid_auth_token(adjust_config, trailing_space):
     """Test config with valid auth_token."""
+    config = adjust_config(
+            add_trailing_space=(trailing_space == 'trailing_space'),
+    )
     out, err, exitcode = run(f'rauc-hawkbit-updater -c "{config}" -r')
 
     assert exitcode == 0


### PR DESCRIPTION
It is not expected that trailing spaces from a config option are used, so strip them. This avoids situations where a trailing space in target_name breaks URLs and more.

Note that trailing spaces in integer option values are already ignored since GLib 2.31.0 ([7a45dde4f](https://gitlab.gnome.org/GNOME/glib/-/commit/7a45dde4f)).


Fixes #96.