### PR TITLE
allow more generic version numbering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (SYSTEMD_FOUND AND "${SYSTEMD_SERVICES_INSTALL_DIR}" STREQUAL "")
 		"${SYSTEMD_SERVICES_INSTALL_DIR}")
 endif ()
 
-add_definitions( -DPROJECT_VERSION=${CMAKE_PROJECT_VERSION} )
+add_definitions( -DPROJECT_VERSION="${CMAKE_PROJECT_VERSION}" )
 
 pkg_check_modules(CURL REQUIRED libcurl>=7.47.0)
 include_directories(${CURL_INCLUDE_DIRS})

--- a/src/rauc-hawkbit-updater.c
+++ b/src/rauc-hawkbit-updater.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
         }
 
         if (opt_version) {
-                g_printf("Version %.1f\n", VERSION);
+                g_printf("Version %s\n", PROJECT_VERSION);
                 return 0;
         }
 


### PR DESCRIPTION
Do not treat version as float which would limit versions to major.minor. Instead handle it as string.

This way it is limited only by the restrictions CMake brings in (format must be major.minor.patch.tweak where each component must be a number).

Signed-off-by: Enrico Joerns <ejo@pengutronix.de>