### PR TITLE
test: allow using remote hawkbit instance and nginx testing proxy via IPv6

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -242,6 +242,7 @@ http {{
 
     server {{
         listen {port};
+        listen [::]:{port};
 
         location / {{
             proxy_pass http://localhost:8080;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,7 +29,7 @@ def hawkbit(pytestconfig):
     """Instance of HawkbitMgmtTestClient connecting to a hawkBit instance."""
     from uuid import uuid4
 
-    host, port = pytestconfig.option.hawkbit_instance.split(':')
+    host, port = pytestconfig.option.hawkbit_instance.rsplit(':', 1)
     client = HawkbitMgmtTestClient(host, int(port))
 
     client.set_config('pollingTime', '00:00:30')


### PR DESCRIPTION
To allow IPv6 addresses in `--hawkbit-instance`, split once at the rightmost colon instead of on every colon, which effectively
breaks IPv6 addresses.

By default, nginx only binds to IPv4. Allow usage of the testing proxy also via IPv6.
