### PR TITLE
Do not include glibc-specific bits/types/struct_tm.h

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -26,7 +26,6 @@
 #include <glib/gstdio.h>
 #include <json-glib/json-glib.h>
 #include <libgen.h>
-#include <bits/types/struct_tm.h>
 #include <gio/gio.h>
 #include <sys/reboot.h>
 


### PR DESCRIPTION
This fails to compile against musl. The time.h include is sufficient.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>