### PR TITLE
drop virtualenv test dependency, improve README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install test dependencies
       run: |
-        sudo apt-get install libgirepository1.0-dev python3-virtualenv nginx-full
+        sudo apt-get install libgirepository1.0-dev nginx-full
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Test Suite
 Prepare test suite:
 
 ```shell
+$ sudo apt install libgirepository1.0-dev nginx-full
 $ python3 -m venv venv
 $ source venv/bin/activate
 (venv) $ pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Test Suite
 Prepare test suite:
 
 ```shell
-virtualenv -p python3 venv
+python3 -m venv venv
 source venv/bin/activate
 python -m pip install --upgrade pip
 pip install -r test-requirements.txt

--- a/README.md
+++ b/README.md
@@ -90,23 +90,23 @@ Test Suite
 Prepare test suite:
 
 ```shell
-python3 -m venv venv
-source venv/bin/activate
-python -m pip install --upgrade pip
-pip install -r test-requirements.txt
+$ python3 -m venv venv
+$ source venv/bin/activate
+(venv) $ pip install --upgrade pip
+(venv) $ pip install -r test-requirements.txt
 ```
 
 Run hawkBit docker container:
 
 ```shell
-docker pull hawkbit/hawkbit-update-server
-docker run -d --name hawkbit -p 8080:8080 hawkbit/hawkbit-update-server
+$ docker pull hawkbit/hawkbit-update-server
+$ docker run -d --name hawkbit -p 8080:8080 hawkbit/hawkbit-update-server
 ```
 
 Run test suite:
 
 ```shell
-./test/wait-for-hawkbit-online && dbus-run-session -- pytest -v
+(venv) $ ./test/wait-for-hawkbit-online && dbus-run-session -- pytest -v
 ```
 
 Pass `-o log_cli=true` to pytest in order to enable live logging for all test cases.


### PR DESCRIPTION
Small collection of testing related improvements:
- github/README: drop python virtualenv test dependency
- README: clarify which calls must be run in the venv
- README: mention test dependencies