### PR TITLE
Drop unused variables

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -263,7 +263,6 @@ static gboolean get_binary(const gchar *download_url, const gchar *file, curl_of
         CURLcode curl_code;
         glong http_code = 0;
         struct curl_slist *headers = NULL;
-        g_autofree gchar *token = NULL;
 
         g_return_val_if_fail(download_url, FALSE);
         g_return_val_if_fail(file, FALSE);
@@ -374,7 +373,7 @@ static gboolean rest_request(enum HTTPMethod method, const gchar *url,
                              JsonBuilder *jsonRequestBody, JsonParser **jsonResponseParser,
                              GError **error)
 {
-        g_autofree gchar *postdata = NULL, *token = NULL;
+        g_autofree gchar *postdata = NULL;
         g_autoptr(RestPayload) fetch_buffer = NULL;
         struct curl_slist *headers = NULL;
         g_autoptr(CURL) curl = NULL;

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1336,9 +1336,9 @@ int hawkbit_start_service_sync()
         g_autoptr(GMainContext) ctx = NULL;
         ClientData cdata;
         g_autoptr(GSource) timeout_source = NULL;
-        g_autoptr(GSource) event_source = NULL;
         int res = 0;
 #ifdef WITH_SYSTEMD
+        g_autoptr(GSource) event_source = NULL;
         g_autoptr(sd_event) event = NULL;
 #endif
 


### PR DESCRIPTION
The `token` variables in `get_binary()`/`rest_request()` are obsolete since the refactoring of the curl options. So drop them.

`event_source` is only used within the `WITH_SYSTEMD` ifdef, so move its declaration there, too.