### PR TITLE
test: helper: use basename or python module as logger name

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -29,6 +29,20 @@ class PExpectLogger:
 
         self.data = b''
 
+def logger_from_command(command):
+    """
+    Returns a logger named after the executable, or in case of a python executable, after the
+    python module,
+    """
+    cmd_parts = command.split()
+    base_cmd = os.path.basename(cmd_parts[0])
+    try:
+        if base_cmd.startswith('python') and cmd_parts[1] == '-m':
+            base_cmd = command.split()[2]
+    except IndexError:
+        pass
+
+    return logging.getLogger(base_cmd)
 
 def run_pexpect(command, *, timeout=30, cwd=None):
     """
@@ -37,8 +51,7 @@ def run_pexpect(command, *, timeout=30, cwd=None):
     stdout/stderr/exit code.
     """
     import pexpect
-
-    logger = logging.getLogger(command.split()[0])
+    logger = logger_from_command(command)
     logger.info('running: %s', command)
 
     pexpect_log = PExpectLogger(logger=logger)
@@ -50,7 +63,7 @@ def run(command, *, timeout=30):
     until command terminates. Logs command and its stdout/stderr/exit code.
     Returns tuple (stdout, stderr, exit code).
     """
-    logger = logging.getLogger(command.split()[0])
+    logger = logger_from_command(command)
     logger.info('running: %s', command)
 
     proc = subprocess.run(shlex.split(command), capture_output=True, text=True, check=False,


### PR DESCRIPTION
The test suite runs various commands, e.g. rauc-hawkbit-updater, nginx, but also stand-alone python modules, e.g. rauc_dbus_dummy (see #83, d63f0e02 ("test: add RAUC D-Bus dummy helper") for the reasoning).

Until now the first component of the command is used as the name of the logger, so we know which command printed what stdout/stderr lines. Since the python module is called via `/path/to/venv/bin/python -m modulename`, the first component might not be helpful and long.

So use the basename of the first component generally. If this component happens to be the Python interpreter called with a module, use the module's name as the name of the logger.

This should help identify the actual command emitting output during tests.