### PR TITLE
test: read output of process until EOF

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -197,6 +197,8 @@ def rauc_dbus_install_success(rauc_bundle):
     Creates a RAUC D-Bus dummy interface on the SessionBus mimicing a successful installation on
     Install().
     """
+    import pexpect
+
     proc = run_pexpect(f'{sys.executable} -m rauc_dbus_dummy {rauc_bundle}',
                        cwd=os.path.dirname(__file__))
     proc.expect('Interface published')
@@ -205,6 +207,7 @@ def rauc_dbus_install_success(rauc_bundle):
 
     assert proc.isalive()
     assert proc.terminate(force=True)
+    proc.expect(pexpect.EOF)
 
 @pytest.fixture
 def rauc_dbus_install_failure(rauc_bundle):
@@ -301,6 +304,7 @@ def nginx_proxy(nginx_config):
     for proc in procs:
         assert proc.isalive()
         proc.terminate(force=True)
+        proc.expect(pexpect.EOF)
 
 @pytest.fixture(scope='session')
 def rate_limited_port(nginx_proxy):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -92,7 +92,6 @@ def adjust_config(config):
     Adjusts the rauc-hawkbit-updater configuration created by the config fixture by
     adding/overwriting or removing options.
     """
-    config_files = []
     def _adjust_config(options={'client': {}}, remove={}, add_trailing_space=False):
         adjusted_config = ConfigParser()
         adjusted_config.read(config)

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 # SPDX-FileCopyrightText: 2021 Bastian Krause <bst@pengutronix.de>, Pengutronix
 
-from pexpect import TIMEOUT
+from pexpect import TIMEOUT, EOF
 
 from helper import run, run_pexpect
 
@@ -55,6 +55,7 @@ def test_cancel_during_download(hawkbit, adjust_config, bundle_assigned, rate_li
     # wait for feedback to arrive at hawkbit server
     proc.expect(TIMEOUT, timeout=2)
     proc.terminate(force=True)
+    proc.expect(EOF)
 
     cancel = hawkbit.get_action()
     assert cancel['type'] == 'cancel'
@@ -80,6 +81,7 @@ def test_cancel_during_install(hawkbit, config, bundle_assigned, rauc_dbus_insta
     # wait for feedback to arrive at hawkbit server
     proc.expect(TIMEOUT, timeout=2)
     proc.terminate(force=True)
+    proc.expect(EOF)
 
     cancel = hawkbit.get_action()
     assert cancel['type'] == 'update'

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -4,7 +4,7 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from pexpect import TIMEOUT
+from pexpect import TIMEOUT, EOF
 
 from helper import run, run_pexpect, timezone_offset_utc
 
@@ -87,6 +87,7 @@ def test_install_maintenance_window(hawkbit, config, rauc_bundle, assign_bundle,
     # let feedback propagate to hawkBit before termination
     proc.expect(TIMEOUT, timeout=2)
     proc.terminate(force=True)
+    proc.expect(EOF)
 
     status = hawkbit.get_action_status()
     assert status[0]['type'] == 'finished'


### PR DESCRIPTION
The tests run various processes, such as rauc-hawkbit-updater, nginx or rauc_dbus_dummy. The output of these processes is currently only read until we see the string/regex we expect. Everything else is not read and does not end up in the logs.

This is confusing to the person running the tests, because errors, tracebacks and other output the tests do not rely on is not logged.

To change this, read all relevant process output (until `EOF`) after the processes are terminated.

While at it, drop an unused line from conftest. It was there since the introduction of the Python test suite. It is a relict of a prior implementation.

