### PR TITLE
Use RAUC's InstallBundle() D-Bus method instead of Install()

### DIFF
--- a/src/rauc-installer.c
+++ b/src/rauc-installer.c
@@ -138,6 +138,7 @@ static gpointer install_loop_thread(gpointer data)
                             ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
         RInstaller *r_installer_proxy = NULL;
         g_autoptr(GError) error = NULL;
+        g_auto(GVariantDict) args = G_VARIANT_DICT_INIT(NULL);
         struct install_context *context = NULL;
 
         g_return_val_if_fail(data, NULL);
@@ -165,7 +166,8 @@ static gpointer install_loop_thread(gpointer data)
         }
 
         g_debug("Trying to contact RAUC DBUS service");
-        if (!r_installer_call_install_sync(r_installer_proxy, context->bundle, NULL, &error)) {
+        if (!r_installer_call_install_bundle_sync(r_installer_proxy, context->bundle,
+                                                  g_variant_dict_end(&args), NULL, &error)) {
                 g_warning("%s", error->message);
                 goto out_loop;
         }

--- a/src/rauc-installer.xml
+++ b/src/rauc-installer.xml
@@ -1,3 +1,4 @@
+<!-- License note: This file is considered data and thus no license is needed for any usage. -->
 <node>
   <interface name="de.pengutronix.rauc.Installer">
     <!--
@@ -7,13 +8,26 @@
          Triggers an installation.
     -->
     <method name="Install">
-      <arg name="source" type="s"/>
+      <arg name="source" type="s" direction="in"/>
+    </method>
+
+    <!--
+         InstallBundle:
+         @source: Path to bundle to be installed
+         @args: Additional arguments to pass
+
+         Triggers an installation.
+    -->
+    <method name="InstallBundle">
+      <arg name="source" type="s" direction="in"/>
+      <arg name="args" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
 
    <!--
     Info: D-Bus variant of rauc info <bundle>
     @bundle: full path to the queried bundle.
-    @compatile: the compatible string from the bundle
+    @compatible: the compatible string from the bundle
     @version: the version string from the bundle
    -->
    <method name="Info">
@@ -32,7 +46,7 @@
              "activated slot rootfs.0")
 
          Keeps a slot bootable (state == "good"), makes it unbootable (state ==
-         "bad") or explicitely activates it for the next boot (state == "active").
+         "bad") or explicitly activates it for the next boot (state == "active").
     -->
     <method name="Mark">
       <arg name="state" type="s" direction="in"/>
@@ -50,15 +64,34 @@
     -->
     <method name="GetSlotStatus">
       <arg name="slot_status_array" type="a(sa{sv})" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="RaucSlotStatusArray"/>
     </method>
 
     <!-- Operation: Represents the current (global) operation rauc performs -->
     <property name="Operation" type="s" access="read"/>
     <!-- LastError: Holds a message describing the last error that occurred -->
     <property name="LastError" type="s" access="read"/>
-    <!-- Progress: Provides installation progress informations in the form
+    <!-- Progress: Provides installation progress information in the form
          (percentage, message, nesting depth) -->
-    <property name="Progress" type="(isi)" access="read"/>
+    <property name="Progress" type="(isi)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="RaucProgress"/>
+    </property>
+    <!-- Compatible: Represents the system's compatible -->
+    <property name="Compatible" type="s" access="read"/>
+    <!-- Variant: Represents the system's variant -->
+    <property name="Variant" type="s" access="read"/>
+    <!-- BootSlot: Represents the slot booted from -->
+    <property name="BootSlot" type="s" access="read"/>
+    <!--
+         GetPrimary:
+         @slot_status_array: array of (slotname, dict) tuples with each
+             dictionary representing the status of the corresponding slot
+
+         Call the bootloader interface to get the primary boot slot
+    -->
+    <method name="GetPrimary">
+      <arg name="primary" type="s" direction="out"/>
+    </method>
 
     <!--
          Completed:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -195,7 +195,7 @@ def bundle_assigned(assign_bundle):
 def rauc_dbus_install_success(rauc_bundle):
     """
     Creates a RAUC D-Bus dummy interface on the SessionBus mimicing a successful installation on
-    Install().
+    InstallBundle().
     """
     proc = run_pexpect(f'{sys.executable} -m rauc_dbus_dummy {rauc_bundle}',
                        cwd=os.path.dirname(__file__))
@@ -210,7 +210,7 @@ def rauc_dbus_install_success(rauc_bundle):
 def rauc_dbus_install_failure(rauc_bundle):
     """
     Creates a RAUC D-Bus dummy interface on the SessionBus mimicing a failing installation on
-    Install().
+    InstallBundle().
     """
     proc = run_pexpect(f'{sys.executable} -m rauc_dbus_dummy {rauc_bundle} --completed-code=1',
                        cwd=os.path.dirname(__file__), timeout=None)

--- a/test/rauc_dbus_dummy.py
+++ b/test/rauc_dbus_dummy.py
@@ -35,7 +35,7 @@ class Installer:
         self._last_error = ''
         self._progress = 0, '', 1
 
-    def Install(self, source):
+    def InstallBundle(self, source, args):
         def mimic_install():
             """Mimics a sucessful/failing installation, depending on `self._completed_code`."""
             progresses = [

--- a/test/rauc_dbus_dummy.py
+++ b/test/rauc_dbus_dummy.py
@@ -124,6 +124,18 @@ class Installer:
         self._last_error = value
         self.PropertiesChanged(Installer.interface, {'LastError': self.LastError}, [])
 
+    @property
+    def Compatible(self):
+        return "not implemented"
+
+    @property
+    def Variant(self):
+        return "not implemented"
+
+    @property
+    def BootSlot(self):
+        return "not implemented"
+
 
 if __name__ == '__main__':
     import argparse


### PR DESCRIPTION
Starting with RAUC [v1.3](https://github.com/rauc/rauc/releases/tag/v1.3), a new `InstallBundle()` D-Bus method for triggering installations was introduced.
Compared to the older `Install()` method, this one allows passing additional options to the installation process. This will be needed in a future PR introducing [streaming support](https://rauc.readthedocs.io/en/latest/advanced.html#http-streaming) in rauc-hawkbit-updater.

The older `Install()` method was deprecated and is likely to be removed in any later versions of RAUC.

To be able to use the new method, sync the D-Bus interface XML with upstream RAUC, adjust the dummy D-Bus interface for testing to expose the method and use the new method in rauc-hawkbit-updater's rauc-installer accordingly. While at it, implement the remaining D-Bus properties as stubs to make `org.freedesktop.DBus.Properties.GetAll()` happy, thus preventing unrelated exceptions in the test suite.