### PR TITLE
config-file/test: make error messages more consistent

### DIFF
--- a/src/config-file.c
+++ b/src/config-file.c
@@ -261,12 +261,12 @@ Config* load_config_file(const gchar *config_file, GError **error)
                                                   &config->gateway_token, NULL, NULL);
         if (!key_auth_token_exists && !key_gateway_token_exists) {
                 g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
-                            "Neither auth_token nor gateway_token is set in the config.");
+                            "Neither 'auth_token' nor 'gateway_token' set");
                 return NULL;
         }
         if (key_auth_token_exists && key_gateway_token_exists) {
                 g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
-                            "Both auth_token and gateway_token are set in the config.");
+                            "Both 'auth_token' and 'gateway_token' set");
                 return NULL;
         }
 
@@ -314,7 +314,7 @@ Config* load_config_file(const gchar *config_file, GError **error)
             config->timeout < config->connect_timeout) {
                 g_set_error(error,
                             G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
-                            "timeout (%d) must be greater than connect_timeout (%d)",
+                            "'timeout' (%d) must be greater than 'connect_timeout' (%d)",
                             config->timeout, config->connect_timeout);
                 return NULL;
         }

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -50,7 +50,7 @@ def test_config_no_auth_token(adjust_config):
     assert exitcode == 4
     assert out == ''
     assert err.strip() == \
-            'Loading config file failed: Neither auth_token nor gateway_token is set in the config.'
+            "Loading config file failed: Neither 'auth_token' nor 'gateway_token' set"
 
 def test_config_multiple_auth_methods(adjust_config):
     """Test config with auth_token and gateway_token options in client section."""
@@ -61,7 +61,7 @@ def test_config_multiple_auth_methods(adjust_config):
     assert exitcode == 4
     assert out == ''
     assert err.strip() == \
-            'Loading config file failed: Both auth_token and gateway_token are set in the config.'
+            "Loading config file failed: Both 'auth_token' and 'gateway_token' set"
 
 def test_register_and_check_invalid_gateway_token(adjust_config):
     """Test config with invalid gateway_token."""


### PR DESCRIPTION
Drop unnecessary redundancies in error messages, since they are prefixed with "Loading config file failed: " anyway. Drop periods at the end of the messages. Use single quotes around option names for better comprehensibility.