### PR TITLE
Fixed inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Setup target (device) configuration file:
   timeout                   = 60
   log_level                 = debug
   post_update_reboot        = false
-  #enable_streaming         = true
+  #stream_bundle            = true
 
   [device]
   product                   = Terminator


### PR DESCRIPTION
`enable_streaming` should be `stream_bundle`
Sorry for the multiple PRs. I got confused how to add the Signed-oof and then used the wrong branch.

Signed-off-by: Lukas Reinecke <lukas.reinecke@epis.de>

Fixes: #142