### PR TITLE
github: bump action versions to fix deprecation warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         whoami
         gcc --version
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install required packages
       run: |
@@ -37,7 +37,7 @@ jobs:
         ninja -C build dist
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -48,7 +48,7 @@ jobs:
         pip install -r test-requirements.txt
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       if: github.ref == 'refs/heads/master'
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -69,7 +69,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install required packages
       run: |
@@ -85,7 +85,7 @@ jobs:
   uncrustify:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run uncrustify check
       run: |


### PR DESCRIPTION
Fixes warnings such as [1]:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, docker/login-action, docker/login-action, actions/setup-python, actions/checkout
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

[1] https://github.com/rauc/rauc-hawkbit-updater/actions/runs/3311891467