### PR TITLE
Fix Omitted Bundle Download Location For Streaming Installations

### DIFF
--- a/test/test_install.py
+++ b/test/test_install.py
@@ -15,6 +15,7 @@ def install_config(config, adjust_config):
         if mode == 'streaming':
             return adjust_config(
                 {'client': {'stream_bundle': 'true'}},
+                remove={'client': 'bundle_download_location'},
             )
         return config
 


### PR DESCRIPTION
Since the integration of RAUC streaming support in rauc-hawkbit-updater [1] the `bundle_download_location` config option can be ommited when the `stream_bundle` config option is enabled [2].

The value of the `bundle_download_location` config option is still used in streaming installation code paths leading to errors such as:
```
g_file_test: assertion 'filename != NULL' failed
```
To fix this, exit early in bundle clean up code and omit the check for free space if the `stream_bundle` config option is enabled.

We should omit the `bundle_download_location` config option for streaming installations in the install tests, because this is the critical code path for streaming installations. Specifying the option for this use case does not make a difference, so we do not need to test it.

[1] https://github.com/rauc/rauc-hawkbit-updater/pull/130
[2] fe30f971 ("hawkbit-client/config-file: implement http streaming support")

Fixes #149 