### PR TITLE
Share connection between curl requests

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -70,6 +70,10 @@ static GSourceFunc software_ready_cb;
 static struct HawkbitAction *active_action = NULL;
 static GThread *thread_download = NULL;
 
+static gsize curl_share_initialized = 0;
+static CURLSH *curl_share = NULL;
+static GMutex curl_share_locks[CURL_LOCK_DATA_LAST + 1];
+
 GQuark rhu_hawkbit_client_error_quark(void)
 {
         return g_quark_from_static_string("rhu_hawkbit_client_error_quark");
@@ -85,6 +89,20 @@ GQuark rhu_hawkbit_client_http_error_quark(void)
         return g_quark_from_static_string("rhu_hawkbit_client_http_error_quark");
 }
 
+void curl_share_lock(CURL *handle, curl_lock_data data, curl_lock_access access, void *clientp)
+{
+        g_return_if_fail(data <= CURL_LOCK_DATA_LAST);
+
+        g_mutex_lock(&curl_share_locks[data]);
+}
+
+
+void curl_share_unlock(CURL *handle, curl_lock_data data, curl_lock_access access, void *clientp)
+{
+        g_return_if_fail(data <= CURL_LOCK_DATA_LAST);
+
+        g_mutex_unlock(&curl_share_locks[data]);
+}
 /**
  * @brief Create and initialize an HawkbitAction.
  *
@@ -256,6 +274,25 @@ static void set_default_curl_opts(CURL *curl)
         curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, hawkbit_config->connect_timeout);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, hawkbit_config->ssl_verify ? 1L : 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, hawkbit_config->ssl_verify ? 1L : 0L);
+
+        if (g_once_init_enter(&curl_share_initialized)) {
+                /* initialize mutexes for different types of data that curl uses locks for */
+                for (gint i = 0; i <= CURL_LOCK_DATA_LAST; i++)
+                        g_mutex_init(&curl_share_locks[i]);
+
+                curl_share = curl_share_init();
+                g_assert_nonnull(curl_share);
+                curl_share_setopt(curl_share, CURLSHOPT_LOCKFUNC, curl_share_lock);
+                curl_share_setopt(curl_share, CURLSHOPT_UNLOCKFUNC, curl_share_unlock);
+                curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+                curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_PSL);
+                curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+                curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+
+                g_once_init_leave(&curl_share_initialized, 1);
+        }
+
+        curl_easy_setopt(curl, CURLOPT_SHARE, curl_share);
 }
 
 /**
@@ -1481,6 +1518,11 @@ finish:
         g_source_destroy(event_source);
         sd_event_set_watchdog(event, FALSE);
 #endif
+        curl_share_cleanup(curl_share);
+
+        for (gint i = 0; i <= CURL_LOCK_DATA_LAST; i++)
+                g_mutex_clear(&curl_share_locks[i]);
+
         g_main_loop_unref(cdata.loop);
         if (res < 0)
                 g_warning("%s", strerror(-res));


### PR DESCRIPTION
Using a curl_share between curl requests allows sharing an open connection and re-use cached DNS, PSL and TLS session id.

This change allows performing multiple requests without having to do re-perform the (full) TLS handshake.

For reference, on a stm32mp151c with OPTEE + pkcs11 TA a full TLS handshake takes ~8 seconds. Mostly due to small pager pool (internal sram) available for OPTEE.

With this change a mTLS curl request take around 60ms after the initial connection has been established.