### PR TITLE
test: fix nginx to run as non-root user

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -258,6 +258,7 @@ def nginx_config(tmp_path_factory, pki_dir):
             location_options=_to_nginx_option(location_options),
             server_options=_to_nginx_option(server_options),
             module_path=os.environ.get('NGINX_MODULES', '/usr/lib/nginx/modules'),
+            nginx_temp=nginx_temp,
         )
         proxy_config.write_text(proxy_config_str)
 

--- a/test/nginx/base.conf.in
+++ b/test/nginx/base.conf.in
@@ -12,6 +12,8 @@ events { }
 
 http {
     access_log /dev/null;
+    client_body_temp_path ${nginx_temp}/client_temp;
+    proxy_temp_path       ${nginx_temp}/proxy_temp_path;
 
     map $$ssl_client_s_dn $$ssl_client_s_dn_cn {
         default "";


### PR DESCRIPTION
Logs

    $ ./test/wait-for-hawkbit-online && dbus-run-session -- pytest -v -o log_cli=true test/test_download.py
    [...]
    test/test_download.py::test_download_too_slow
    -------------------------------------------------------- live log call --------------------------------------------------------
    INFO nginx running: nginx -c /tmp/pytest-of-thibaud/pytest-8/nginx0/nginx.conf -p .
    INFO nginx nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (13: Permission denied)
    INFO nginx 2024/06/28 15:41:56 [emerg] 1450257#1450257: mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
    SKIPPED (nginx failed, use -s to see logs)                                                                              [ 42%]
    test/test_download.py::test_download_partials_without_resume
    ------------------------------------------------------- live log setup --------------------------------------------------------
    INFO nginx running: nginx -c /tmp/pytest-of-thibaud/pytest-8/nginx1/nginx.conf -p .
    INFO nginx nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (13: Permission denied)
    INFO nginx 2024/06/28 15:41:56 [emerg] 1450258#1450258: mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
    SKIPPED (nginx failed, use -s to see logs)                                                                              [ 57%]
    test/test_download.py::test_download_partials_with_resume SKIPPED (nginx failed, use -s to see logs)                    [ 71%]
    test/test_download.py::test_download_slow_with_resume
    -------------------------------------------------------- live log call --------------------------------------------------------
    INFO nginx running: nginx -c /tmp/pytest-of-thibaud/pytest-8/nginx2/nginx.conf -p .
    INFO nginx nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (13: Permission denied)
    INFO nginx 2024/06/28 15:41:56 [emerg] 1450259#1450259: mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
    SKIPPED (nginx failed, use -s to see logs)


Run on Fedora 40 with following rpm packages installed:
```
meson
ninja-build
libcurl-devel
json-glib-devel
python3-sphinx

# Needed by pip install -r test-requirements.txt
pkg-config
cairo
cairo-devel
cairo-gobject-devel
gobject-introspection
gobject-introspection-devel

nginx
nginx-all-modules
```