### PR TITLE
Build and Test Fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install test dependencies
       run: |
-        sudo apt-get install libgirepository1.0-dev nginx-full
+        sudo apt-get install libcairo2-dev libgirepository1.0-dev nginx-full
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build (with ${{ matrix.options }} ${{ matrix.flags }})
       run: |
-        ${{ matrix.flags }} meson build ${{ matrix.options }} -Dwerror=true
+        ${{ matrix.flags }} meson setup build ${{ matrix.options }} -Dwerror=true
         ninja -C build
 
     - name: Build release
@@ -78,7 +78,7 @@ jobs:
 
     - name: Meson Build documentation (Sphinx & Doxygen)
       run: |
-        meson build
+        meson setup build
         ninja -C build docs/html
         ninja -C build doxygen
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Test Suite
 Prepare test suite:
 
 ```shell
-$ sudo apt install libgirepository1.0-dev nginx-full
+$ sudo apt install libcairo2-dev libgirepository1.0-dev nginx-full
 $ python3 -m venv venv
 $ source venv/bin/activate
 (venv) $ pip install --upgrade pip

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   version : '1.3',
   meson_version : '>=0.50',
   default_options: [
-    'warning_level=3',
+    'warning_level=2',
   ],
   license : 'LGPL-2.1-only',
 )


### PR DESCRIPTION
- github: tests: use non-ambiguous "meson setup build"
- meson: decrease warning_level to 2
- github/README: add libcairo2-dev to test dependencies

This should also fix the CI builds/tests.