### PR TITLE
github: codeql: bump to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: cpp
           queries: +security-and-quality
@@ -38,6 +38,6 @@ jobs:
           meson compile -C build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:cpp"


### PR DESCRIPTION
v2 is deprecated [1], so switch to v3.

[1] https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/