### PR TITLE
testing: bind hawkbit/nginx locally only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,8 @@ jobs:
     - name: Update/launch hawkBit docker container
       run: |
         docker pull hawkbit/hawkbit-update-server
-        docker run -d --name hawkbit -p 8080:8080 hawkbit/hawkbit-update-server \
+        docker run -d --name hawkbit -p ::1:8080:8080 -p 127.0.0.1:8080:8080 \
+          hawkbit/hawkbit-update-server \
           --hawkbit.server.security.dos.filter.enabled=false \
           --hawkbit.server.security.dos.maxStatusEntriesPerAction=-1
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Run hawkBit docker container:
 
 ```shell
 $ docker pull hawkbit/hawkbit-update-server
-$ docker run -d --name hawkbit -p 8080:8080 hawkbit/hawkbit-update-server \
+$ docker run -d --name hawkbit -p ::1:8080:8080 -p 127.0.0.1:8080:8080 \
+    hawkbit/hawkbit-update-server \
     --hawkbit.server.security.dos.filter.enabled=false \
     --hawkbit.server.security.dos.maxStatusEntriesPerAction=-1
 ```

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -244,8 +244,8 @@ http {{
     access_log /dev/null;
 
     server {{
-        listen {port};
-        listen [::]:{port};
+        listen 127.0.0.1:{port};
+        listen [::1]:{port};
 
         location / {{
             proxy_pass http://localhost:8080;


### PR DESCRIPTION
For testing purposes, it is generally not needed to bind against anything else than localhost. A malicious actor can potentially do bad things with the default configuration of the hawkbit container, so bind locally only.

Depending on the system configuration, localhost can resolve to ::1 or 127.0.0.1. docker does not support binding to localhost, only to an IP address. So simply let nginx and the hawkbit docker container bind to both IPv4 and IPv6 locally.
