### PR TITLE
test: conftest: drop anonymous download hawkBit option

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,7 +37,6 @@ def hawkbit(pytestconfig):
     client.set_config('authentication.targettoken.enabled', True)
     client.set_config('authentication.gatewaytoken.enabled', True)
     client.set_config('authentication.gatewaytoken.key', uuid4().hex)
-    client.set_config('anonymous.download.enabled', False)
 
     return client
 


### PR DESCRIPTION
hawkBit 0.8.0 [1] removed the option `anonymous.download.enabled` [2]. Anonymous downloads are no longer allowed. That means we can drop the configuration altogether because we've disabled that option before, anyway.

[1] https://github.com/eclipse-hawkbit/hawkbit/releases/tag/0.8.0
[2] https://github.com/eclipse-hawkbit/hawkbit/commit/54a53a36314f82ca0572330b68d499e715d81b24