### PR TITLE
hawkbit-client: poll in 10s if an activity was performed

### DIFF
--- a/include/config-file.h
+++ b/include/config-file.h
@@ -31,6 +31,7 @@ typedef struct Config_ {
         int retry_wait;                   /**< wait between retries */
         int low_speed_time;               /**< time to be below the speed to trigger low speed abort */
         int low_speed_rate;               /**< low speed limit to abort transfer */
+        int hawkbit_interval_active_override;       /**< hawkbit check interval */
         GLogLevelFlags log_level;         /**< log level */
         GHashTable* device;               /**< Additional attributes sent to hawkBit */
         gboolean send_download_authentication; /**< Send security header in download requests */

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -18,6 +18,7 @@ static const gint DEFAULT_RETRY_WAIT      = 5 * 60; // 5 min.
 static const gboolean DEFAULT_SSL         = TRUE;
 static const gboolean DEFAULT_SSL_VERIFY  = TRUE;
 static const gboolean DEFAULT_REBOOT      = FALSE;
+static const gint DEFAULT_HAWKBIT_INTERVAL_ACTIVE_OVERRIDE = -1;
 static const gchar* DEFAULT_LOG_LEVEL     = "message";
 static const gboolean DEFAULT_SEND_DOWNLOAD_AUTHENTICATION = TRUE;
 
@@ -328,6 +329,10 @@ Config* load_config_file(const gchar *config_file, GError **error)
                 return NULL;
         if (!get_key_int(ini_file, "client", "low_speed_time", &config->low_speed_time, 60, error))
                 return NULL;
+        if (!get_key_int(ini_file, "client", "hawkbit_interval_active_override", &config->hawkbit_interval_active_override,
+                         DEFAULT_HAWKBIT_INTERVAL_ACTIVE_OVERRIDE, error))
+                return NULL;
+        g_debug("hawkbit_interval_active_override: %d", config->hawkbit_interval_active_override);
         if (!get_key_bool(ini_file, "client", "resume_downloads", &config->resume_downloads, FALSE,
                           error))
                 return NULL;

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1438,6 +1438,9 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
         g_autoptr(JsonParser) json_response_parser = NULL;
         JsonNode *json_root = NULL;
 
+        gboolean no_downloads = FALSE;
+        gboolean no_cancellations = FALSE;
+
         g_return_val_if_fail(user_data, FALSE);
 
         if (++data->last_run_sec < data->hawkbit_interval_check_sec)
@@ -1494,6 +1497,7 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
                 }
         } else {
                 g_message("No new software.");
+                no_downloads = TRUE;
         }
         if (json_contains(json_root, "$._links.cancelAction")) {
                 res = process_cancel(json_root, &error);
@@ -1501,10 +1505,12 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
                         g_warning("%s", error->message);
                         g_clear_error(&error);
                 }
+        } else {
+                no_cancellations = TRUE;
         }
 
         // get hawkbit sleep time (how often should we check for new software)
-        data->hawkbit_interval_check_sec = json_get_sleeptime(json_root);
+        data->hawkbit_interval_check_sec = (no_downloads && no_cancellations) ? json_get_sleeptime(json_root) : 10;
 
 out:
         if (run_once) {

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1440,6 +1440,7 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
 
         gboolean no_downloads = FALSE;
         gboolean no_cancellations = FALSE;
+        long check_interval;
 
         g_return_val_if_fail(user_data, FALSE);
 
@@ -1510,7 +1511,11 @@ static gboolean hawkbit_pull_cb(gpointer user_data)
         }
 
         // get hawkbit sleep time (how often should we check for new software)
-        data->hawkbit_interval_check_sec = (no_downloads && no_cancellations) ? json_get_sleeptime(json_root) : 10;
+        check_interval = (hawkbit_config->hawkbit_interval_active_override != -1) ?
+                         hawkbit_config->hawkbit_interval_active_override : json_get_sleeptime(json_root);
+
+        data->hawkbit_interval_check_sec = (no_downloads && no_cancellations) ? json_get_sleeptime(json_root) : check_interval;
+        g_debug("Next check in %ld seconds", data->hawkbit_interval_check_sec);
 
 out:
         if (run_once) {


### PR DESCRIPTION
The function `hawkbit_pull_cb` in [hawkbit-client.c](https://github.com/rauc/rauc-hawkbit-updater/blob/2711c0e02781eb9d97285c87197f1bafef75d0d1/src/hawkbit-client.c#L1432) handles only one action (download or cancellation) every time it runs. 

In cases where a device has many pending actions and has a sensible poll interval, the update is delayed for a significantly long time.

For instance, if a device has 6 updates assigned to it, of which 5 are cancelled and 1 is available for download, and it has been configured to poll the server every 15 minutes, it will take one hour and 15 minutes before it starts downloading the update.

While this isn't a problem for any devices in the field and online, it is a problem for devices that are either offline for a long period, or in our case, devices that have not been deployed yet.

Duplicate: #203 