### PR TITLE
Add identify_on_startup config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Setup target (device) configuration file:
   #resume_downloads             = false
   #stream_bundle                = false
   #post_update_reboot           = false
+  #identify_on_startup          = false
   #log_level                    = message
   #send_download_authentication = true
 

--- a/config.conf.example
+++ b/config.conf.example
@@ -49,6 +49,9 @@ low_speed_rate            = 0
 # reboot after a successful update
 post_update_reboot        = false
 
+# send device attributes (configData) on startup, regardless of server request
+identify_on_startup       = false
+
 # debug, info, message, critical, error, fatal
 log_level                 = message
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -167,6 +167,12 @@ Optional options:
     manager and without terminating any processes or unmounting any file systems.
     This may result in data loss.
 
+``identify_on_startup=<boolean>``
+  Whether to send device attributes (configData) to the server on startup,
+  regardless of whether the server requests it.
+  This is useful to report the current software version (sw_version) after a reboot.
+  Defaults to ``false``.
+
 ``log_level=<level>``
   Log level to print, where ``level`` is a string of
 

--- a/include/config-file.h
+++ b/include/config-file.h
@@ -34,6 +34,7 @@ typedef struct Config_ {
         GLogLevelFlags log_level;         /**< log level */
         GHashTable* device;               /**< Additional attributes sent to hawkBit */
         gboolean send_download_authentication; /**< Send security header in download requests */
+        gboolean identify_on_startup;     /**< Send device attributes (configData) on startup */
 } Config;
 
 /**

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -346,6 +346,10 @@ Config* load_config_file(const gchar *config_file, GError **error)
                           DEFAULT_SEND_DOWNLOAD_AUTHENTICATION, error))
                 return NULL;
 
+        if (!get_key_bool(ini_file, "client", "identify_on_startup",
+                          &config->identify_on_startup, FALSE, error))
+                return NULL;
+
         if (config->timeout > 0 && config->connect_timeout > 0 &&
             config->timeout < config->connect_timeout) {
                 g_set_error(error,

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1534,6 +1534,14 @@ int hawkbit_start_service_sync()
 
         active_action = action_new();
 
+        // Optionally send device attributes (configData) on startup
+        if (hawkbit_config->identify_on_startup) {
+                g_autoptr(GError) error = NULL;
+                g_message("Sending device attributes on startup");
+                if (!identify(&error))
+                        g_warning("Failed to send device attributes on startup: %s", error->message);
+        }
+
         ctx = g_main_context_new();
         cdata.loop = g_main_loop_new(ctx, FALSE);
         cdata.hawkbit_interval_check_sec = hawkbit_config->retry_wait;


### PR DESCRIPTION
When enabled, the client sends device attributes (configData) to the server on startup, regardless of whether the server requests it via the configData link.

This is useful to actively report the current software version (sw_version) after a device reboot.

Default: false (preserves existing behavior)