### PR TITLE
hawkBit 1.0 Adaptions

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -347,7 +347,7 @@ def mtls_download_port(nginx_proxy, ssl_issuer_hash):
     hawkBit instance). Returns the port the proxy is running on. This port can be set in the
     rauc-hawkbit-updater config to test mTLS authentication.
     """
-    location_options = {"proxy_set_header X-Ssl-Issuer-Hash-1": ssl_issuer_hash}
+    location_options = {"proxy_set_header X-Authority-1": ssl_issuer_hash}
     return nginx_proxy(location_options, mtls=True)
 
 @pytest.fixture

--- a/test/nginx/base.conf.in
+++ b/test/nginx/base.conf.in
@@ -39,7 +39,7 @@ http {
             proxy_set_header X-Forwarded-Protocol $$scheme;
             proxy_set_header X-Forwarded-Port ${port};
 
-            proxy_set_header X-Ssl-Client-Cn $$ssl_client_s_dn_cn;
+            proxy_set_header X-Controller-Id $$ssl_client_s_dn_cn;
 
             # These are required for clients to upload and download software.
             proxy_request_buffering off;

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -27,7 +27,7 @@ def test_cancel_before_poll(hawkbit, adjust_config, bundle_assigned, rauc_dbus_i
 
     cancel = hawkbit.get_action()
     assert cancel['type'] == 'cancel'
-    assert cancel['status'] == 'finished'
+    assert cancel['status'] == 'canceled'
 
     cancel_status = hawkbit.get_action_status()
     assert cancel_status[0]['type'] == 'canceled'
@@ -66,7 +66,7 @@ def test_cancel_during_download(hawkbit, adjust_config, bundle_assigned, rate_li
 
     cancel = hawkbit.get_action()
     assert cancel['type'] == 'cancel'
-    assert cancel['status'] == 'finished'
+    assert cancel['status'] == 'canceled'
 
     cancel_status = hawkbit.get_action_status()
     assert cancel_status[0]['type'] == 'canceled'


### PR DESCRIPTION
[hawkBit 1.0](https://github.com/eclipse-hawkbit/hawkbit/releases/tag/1.0.0 ) introduces some minor breaking changes. Adapt our tests accordingly.

I don't think it's worth keeping our test suite compatible to earlier hawkBit versions, meaning these tests will deliberately fail there.

Edit: see latest CI fails on master: https://github.com/rauc/rauc-hawkbit-updater/actions/workflows/tests.yml?query=branch%3Amaster