### PR TITLE
hawkbit-client: do not resume downloads for persistent server errors

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -971,8 +971,15 @@ static gpointer download_thread(gpointer data)
                                resume_from, &sha1sum, &speed, &error))
                         break;
 
+                // resume download under certain conditions
                 for (const gint *code = &resumable_codes[0]; *code; code++)
                         resumable |= g_error_matches(error, RHU_HAWKBIT_CLIENT_CURL_ERROR, *code);
+
+                // but do not resume download on persistent HTTP server errors
+                if (error->domain == RHU_HAWKBIT_CLIENT_HTTP_ERROR &&
+                    error->code >= 400 && error->code < 500 &&
+                    error->code != 408 && error->code != 429)
+                        resumable = FALSE;
 
                 if (!hawkbit_config->resume_downloads || !resumable) {
                         g_prefix_error(&error, "Download failed: ");


### PR DESCRIPTION
Most 4xx HTTP status codes indicate that retrying the request unmodified is not going to lead to success. Exceptions are "408 Request Timeout" and "429 Too Many Requests".

So do not try to resume downloads under these conditions and report an error to hawkBit immediately.

Reported in #158.