### PR TITLE
hawkbit-client:  Add support for soft rollout action type with optional D-Bus readiness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ soft_update_check_force_on_unavailable = true
 
 If `soft_update_check_dbus_service` is not set (the default), soft updates are applied unconditionally.
 
+When `soft_update_check_force_on_unavailable` is `false` and `soft_update_check_unavailable_max_retries` is set to a positive integer, the updater will force the update after that many consecutive poll cycles where the D-Bus service was unreachable. This prevents a permanently unavailable service from blocking updates indefinitely. The retry counter resets when the service becomes reachable again or when a new deployment is received.
+
 **D-Bus policy file (system bus):**
 
 Because the updater connects to the **system bus**, the D-Bus daemon will reject calls to the

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Setup target (device) configuration file:
   #post_update_reboot           = false
   #log_level                    = message
   #send_download_authentication = true
+  #soft_update_check_dbus_service = de.example.SoftUpdateCheck
+  #soft_update_check_force_on_unavailable = true
 
   [device]
   product                   = Terminator
@@ -66,6 +68,82 @@ Finally start the updater as daemon:
 
 ```shell
 $ ./rauc-hawkbit-updater -c config.conf
+```
+
+
+Soft Update Permission Check
+----------------------------
+
+hawkBit supports four rollout action types: **Forced**, **Soft**, **Time Forced**, and
+**Download Only**. For soft updates the server signals that installation is at the device's
+discretion (DDI fields `download=attempt`, `update=attempt`). Time Forced actions report as
+Soft until their deadline, at which point hawkBit switches them to Forced transparently.
+
+The updater can optionally consult an external D-Bus service before proceeding with a soft
+update, allowing another application (e.g. a UI or a workload manager) to gate the
+installation — for example, to defer it until the device is idle.
+
+**How it works:**
+
+1. On each poll cycle, if a soft update is pending the updater calls `IsReadyForUpdate()` on the
+   configured D-Bus service (system bus, object path `/`, interface named after the service).
+2. If the method returns `True` the update proceeds normally.
+3. If the method returns `False` the update is silently skipped and retried on the next poll
+   (controlled by `retry_wait`). No error is reported to hawkBit — the action stays open.
+4. Once the service starts returning `True` the update is applied on the very next poll.
+5. **Forced** and **Download Only** updates always bypass this check.
+
+**Configuration:**
+
+```ini
+[client]
+# D-Bus well-known name of the permission service
+soft_update_check_dbus_service = de.example.SoftUpdateCheck
+
+# Fallback when the service is unreachable: true = force the update (default), false = skip
+soft_update_check_force_on_unavailable = true
+```
+
+**Expected D-Bus interface** (object path `/`, interface = service name):
+
+```xml
+<interface name='de.example.SoftUpdateCheck'>
+  <method name='IsReadyForUpdate'>
+    <arg type='b' name='ready' direction='out'/>
+  </method>
+</interface>
+```
+
+If `soft_update_check_dbus_service` is not set (the default), soft updates are applied unconditionally.
+
+**D-Bus policy file (system bus):**
+
+Because the updater connects to the **system bus**, the D-Bus daemon will reject calls to the
+permission service unless a policy file explicitly grants access. Without it the service will be
+unreachable and the updater will either skip the update or force it through, depending on
+`soft_update_check_force_on_unavailable`.
+
+Create a policy file for your service name, e.g.
+`/etc/dbus-1/system.d/de.example.SoftUpdateCheck.conf`:
+
+```xml
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- allow any process to own the service name and communicate with it -->
+  <policy context="default">
+    <allow own="de.example.SoftUpdateCheck"/>
+    <allow send_destination="de.example.SoftUpdateCheck"/>
+    <allow receive_sender="de.example.SoftUpdateCheck"/>
+  </policy>
+</busconfig>
+```
+
+Replace `de.example.SoftUpdateCheck` with the actual service name configured in
+`soft_update_check_dbus_service`. After installing the file, reload the D-Bus daemon:
+
+```shell
+$ sudo systemctl reload dbus
 ```
 
 
@@ -121,6 +199,14 @@ $ docker run -d --name hawkbit -p ::1:8080:8080 -p 127.0.0.1:8080:8080 \
     --hawkbit.server.security.dos.filter.enabled=false \
     --hawkbit.server.security.dos.maxStatusEntriesPerAction=-1 \
     --server.forward-headers-strategy=NATIVE
+```
+
+If you want to run the soft update permission check tests, install the D-Bus policy file described
+in the `Soft Update Permission Check` section above first (the test dummy connects to the system
+bus and requires it):
+
+```shell
+$ sudo systemctl reload dbus
 ```
 
 Run test suite:

--- a/config.conf.example
+++ b/config.conf.example
@@ -52,6 +52,19 @@ post_update_reboot        = false
 # debug, info, message, critical, error, fatal
 log_level                 = message
 
+# D-Bus well-known service name to call for install permission on soft updates.
+# When set, the client calls IsReadyForUpdate() on the service (system bus, object path "/",
+# interface named after the service) before proceeding with a soft update. If the method
+# returns False the update is skipped and retried on the next poll. Forced and Download Only
+# updates bypass this check entirely.
+# If unset (default), soft updates are applied unconditionally.
+#soft_update_check_dbus_service = de.example.SoftUpdateCheck
+
+# Controls the fallback behavior when soft_update_check_dbus_service is set but the D-Bus
+# service is unreachable (e.g. not running). If true (default), the update proceeds
+# unconditionally. If false, the update is skipped until the service becomes available.
+#soft_update_check_force_on_unavailable = true
+
 # Every key / value under [device] is sent to HawkBit (target attributes),
 # and can be used in target filter.
 [device]

--- a/config.conf.example
+++ b/config.conf.example
@@ -65,6 +65,12 @@ log_level                 = message
 # unconditionally. If false, the update is skipped until the service becomes available.
 #soft_update_check_force_on_unavailable = true
 
+# When soft_update_check_force_on_unavailable is false, this sets the maximum number of
+# consecutive poll cycles in which the D-Bus service is unreachable before the update is
+# forced anyway (to prevent updates from being blocked indefinitely).
+# 0 (default) disables forced retry; the update is skipped until the service reappears.
+#soft_update_check_unavailable_max_retries = 0
+
 # Every key / value under [device] is sent to HawkBit (target attributes),
 # and can be used in target filter.
 [device]

--- a/include/config-file.h
+++ b/include/config-file.h
@@ -34,6 +34,12 @@ typedef struct Config_ {
         GLogLevelFlags log_level;         /**< log level */
         GHashTable* device;               /**< Additional attributes sent to hawkBit */
         gboolean send_download_authentication; /**< Send security header in download requests */
+        gchar* soft_update_check_dbus_service; /**< D-Bus service name to call for soft update
+                                                     permission; NULL disables the check */
+        gboolean soft_update_check_force_on_unavailable; /**< if TRUE (default), proceed with the
+                                                               update when the D-Bus service is
+                                                               unreachable; if FALSE,
+                                                               skip the update */
 } Config;
 
 /**

--- a/include/config-file.h
+++ b/include/config-file.h
@@ -40,6 +40,11 @@ typedef struct Config_ {
                                                                update when the D-Bus service is
                                                                unreachable; if FALSE,
                                                                skip the update */
+        gint soft_update_check_unavailable_max_retries;  /**< when force_on_unavailable is FALSE,
+                                                               number of consecutive poll cycles
+                                                               with an unreachable service after
+                                                               which the update is forced anyway;
+                                                               0 (default) disables forced retry */
 } Config;
 
 /**

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -346,6 +346,12 @@ Config* load_config_file(const gchar *config_file, GError **error)
                           DEFAULT_SEND_DOWNLOAD_AUTHENTICATION, error))
                 return NULL;
 
+        get_key_string(ini_file, "client", "soft_update_check_dbus_service",
+                       &config->soft_update_check_dbus_service, NULL, NULL);
+        if (!get_key_bool(ini_file, "client", "soft_update_check_force_on_unavailable",
+                          &config->soft_update_check_force_on_unavailable, TRUE, error))
+                return NULL;
+
         if (config->timeout > 0 && config->connect_timeout > 0 &&
             config->timeout < config->connect_timeout) {
                 g_set_error(error,
@@ -378,6 +384,7 @@ void config_file_free(Config *config)
         g_free(config->ssl_key);
         g_free(config->ssl_cert);
         g_free(config->bundle_download_location);
+        g_free(config->soft_update_check_dbus_service);
         if (config->device)
                 g_hash_table_destroy(config->device);
         g_free(config);

--- a/src/config-file.c
+++ b/src/config-file.c
@@ -351,6 +351,9 @@ Config* load_config_file(const gchar *config_file, GError **error)
         if (!get_key_bool(ini_file, "client", "soft_update_check_force_on_unavailable",
                           &config->soft_update_check_force_on_unavailable, TRUE, error))
                 return NULL;
+        if (!get_key_int(ini_file, "client", "soft_update_check_unavailable_max_retries",
+                         &config->soft_update_check_unavailable_max_retries, 0, error))
+                return NULL;
 
         if (config->timeout > 0 && config->connect_timeout > 0 &&
             config->timeout < config->connect_timeout) {

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1127,6 +1127,62 @@ static gboolean start_streaming_installation(Artifact *artifact, GError **error)
 }
 
 /**
+ * @brief Ask the configured D-Bus service for permission to proceed with a soft update.
+ *
+ * Calls the IsReadyForUpdate() method on the well-known D-Bus name set in
+ * hawkbit_config->soft_update_check_dbus_service (system bus, object path "/", interface
+ * named after the service). If no service is configured, permission is granted implicitly.
+ *
+ * @param[out] error Error
+ * @return TRUE if install is permitted or no check is configured,
+ *         FALSE without error if the service explicitly denies the update,
+ *         FALSE with error set if the D-Bus call fails
+ */
+static gboolean soft_update_check(GError **error)
+{
+        g_autoptr(GDBusConnection) conn = NULL;
+        g_autoptr(GVariant) result = NULL;
+        gboolean permitted;
+
+        g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+        if (!hawkbit_config->soft_update_check_dbus_service)
+                return TRUE;
+
+        conn = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, error);
+        if (!conn)
+                return FALSE;
+
+        result = g_dbus_connection_call_sync(
+                conn,
+                hawkbit_config->soft_update_check_dbus_service,
+                "/",
+                hawkbit_config->soft_update_check_dbus_service,
+                "IsReadyForUpdate",
+                NULL,
+                G_VARIANT_TYPE("(b)"),
+                G_DBUS_CALL_FLAGS_NONE,
+                -1,
+                NULL,
+                error);
+
+        if (!result) {
+                if (hawkbit_config->soft_update_check_force_on_unavailable) {
+                        g_warning("Soft update permission service unavailable: %s. "
+                                  "Forcing update.", (*error)->message);
+                        g_clear_error(error);
+                        return TRUE;
+                }
+                return FALSE;
+        }
+
+        g_variant_get(result, "(b)", &permitted);
+        if (permitted)
+                g_message("Soft update permission granted.");
+        return permitted;
+}
+
+/**
  * @brief Process hawkBit deployment described by req_root.
  *        Must be called under locked active_action->mutex.
  *
@@ -1140,6 +1196,7 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
         g_autofree gchar *deployment = NULL, *temp_id = NULL,
                          *deployment_download = NULL, *deployment_update = NULL,
                          *maintenance_window = NULL, *maintenance_msg = NULL;
+        const gchar *action_type_label = NULL;
         g_autoptr(JsonParser) json_response_parser = NULL;
         g_autoptr(JsonArray) json_chunks = NULL, json_artifacts = NULL;
         JsonNode *resp_root = NULL, *json_chunk = NULL, *json_artifact = NULL;
@@ -1194,9 +1251,35 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
                 goto error;
 
         artifact->do_install = g_strcmp0(deployment_update, "skip") != 0;
+
+        // infer and log action type from deployment handling types:
+        // Download Only is the only case where update="skip" without a maintenance window
+        if (!artifact->do_install && !maintenance_window)
+                action_type_label = "Download Only";
+        else if (!g_strcmp0(deployment_download, "forced"))
+                action_type_label = "Forced";
+        else
+                action_type_label = "Soft";
+        g_message("Action type: %s.", action_type_label);
+
         if (!artifact->do_install)
                 g_message("hawkBit requested to skip installation, not invoking RAUC yet%s.",
                           maintenance_msg);
+
+        // for soft updates that are ready to install, ask the configured D-Bus service for
+        // permission; Forced and Download Only updates bypass this check
+        if (!g_strcmp0(action_type_label, "Soft") && artifact->do_install) {
+                g_autoptr(GError) soft_error = NULL;
+                if (!soft_update_check(&soft_error)) {
+                        if (soft_error)
+                                g_warning("Soft update permission check failed: %s",
+                                          soft_error->message);
+                        else
+                                g_message("Soft update permission denied, skipping update.");
+                        active_action->state = ACTION_STATE_NONE;
+                        return TRUE;
+                }
+        }
 
         // remember deployment's action id
         temp_id = json_get_string(resp_root, "$.id", error);

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -69,6 +69,7 @@ static Config *hawkbit_config = NULL;
 static GSourceFunc software_ready_cb;
 static struct HawkbitAction *active_action = NULL;
 static GThread *thread_download = NULL;
+static gint soft_update_check_unavailable_count = 0;
 
 static gsize curl_share_initialized = 0;
 static CURLSH *curl_share = NULL;
@@ -869,6 +870,8 @@ static gboolean identify(GError **error)
  */
 static void process_deployment_cleanup()
 {
+        soft_update_check_unavailable_count = 0;
+
         if (!hawkbit_config->bundle_download_location)
                 return;
 
@@ -1173,9 +1176,30 @@ static gboolean soft_update_check(GError **error)
                         g_clear_error(error);
                         return TRUE;
                 }
+
+                soft_update_check_unavailable_count++;
+                gint max = hawkbit_config->soft_update_check_unavailable_max_retries;
+                if (max > 0 && soft_update_check_unavailable_count >= max) {
+                        g_warning("Soft update permission service unavailable for %d consecutive "
+                                  "poll cycles (max_retries=%d): %s. Forcing update.",
+                                  soft_update_check_unavailable_count, max, (*error)->message);
+                        g_clear_error(error);
+                        soft_update_check_unavailable_count = 0;
+                        return TRUE;
+                }
+
+                if (max > 0)
+                        g_warning("Soft update permission service unavailable (attempt %d/%d): %s. "
+                                  "Skipping update.",
+                                  soft_update_check_unavailable_count, max, (*error)->message);
+                else
+                        g_warning("Soft update permission service unavailable (attempt %d): %s. "
+                                  "Skipping update.",
+                                  soft_update_check_unavailable_count, (*error)->message);
                 return FALSE;
         }
 
+        soft_update_check_unavailable_count = 0;
         g_variant_get(result, "(b)", &permitted);
         if (permitted)
                 g_message("Soft update permission granted.");

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -211,6 +211,42 @@ def rauc_dbus_install_success(rauc_bundle):
     proc.expect(pexpect.EOF)
 
 @pytest.fixture
+def soft_update_check_permitted():
+    """
+    Creates a soft update check D-Bus dummy service on the SystemBus that grants update
+    permission when IsReadyForUpdate() is called.
+    """
+    import pexpect
+
+    proc = run_pexpect(f'{sys.executable} -m soft_update_check_dbus_dummy',
+                       cwd=os.path.dirname(__file__))
+    proc.expect('Interface published')
+
+    yield
+
+    assert proc.isalive()
+    assert proc.terminate(force=True)
+    proc.expect(pexpect.EOF)
+
+@pytest.fixture
+def soft_update_check_denied():
+    """
+    Creates a soft update check D-Bus dummy service on the SystemBus that denies update
+    permission when IsReadyForUpdate() is called.
+    """
+    import pexpect
+
+    proc = run_pexpect(f'{sys.executable} -m soft_update_check_dbus_dummy --denied',
+                       cwd=os.path.dirname(__file__))
+    proc.expect('Interface published')
+
+    yield
+
+    assert proc.isalive()
+    assert proc.terminate(force=True)
+    proc.expect(pexpect.EOF)
+
+@pytest.fixture
 def rauc_dbus_install_failure(rauc_bundle):
     """
     Creates a RAUC D-Bus dummy interface on the SessionBus mimicing a failing installation on

--- a/test/soft_update_check_dbus_dummy.py
+++ b/test/soft_update_check_dbus_dummy.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+
+"""
+D-Bus dummy service for soft update permission checks.
+
+Publishes a de.example.SoftUpdateCheck service on the system bus
+exposing an IsReadyForUpdate() method that returns a configurable boolean.
+"""
+
+DBUS_SERVICE_NAME = 'de.example.SoftUpdateCheck'
+
+
+class SoftUpdateCheck:
+    """
+    D-Bus interface `de.example.SoftUpdateCheck.conf`, to be used with
+    `pydbus.SystemBus.publish()`
+    """
+    dbus = f"""
+    <node>
+      <interface name='{DBUS_SERVICE_NAME}'>
+        <method name='IsReadyForUpdate'>
+          <arg type='b' name='ready' direction='out'/>
+        </method>
+      </interface>
+    </node>
+    """
+
+    def __init__(self, permitted=True):
+        self._permitted = permitted
+
+    def IsReadyForUpdate(self):
+        result = 'granted' if self._permitted else 'denied'
+        print(f'IsReadyForUpdate() called, returning {result}')
+        return self._permitted
+
+
+if __name__ == '__main__':
+    import argparse
+    from gi.repository import GLib
+    from pydbus import SystemBus
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--denied', action='store_true',
+                        help='Return False from IsReadyForUpdate() (deny permission)')
+    args = parser.parse_args()
+
+    loop = GLib.MainLoop()
+    bus = SystemBus()
+    service = SoftUpdateCheck(permitted=not args.denied)
+    with bus.publish(DBUS_SERVICE_NAME, ('/', service)):
+        print('Interface published')
+        loop.run()

--- a/test/test_soft.py
+++ b/test/test_soft.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+
+"""
+Tests for soft update behavior and the optional D-Bus update readiness check.
+
+Soft updates (deployment.download="attempt", deployment.update="attempt") differ from forced
+updates in that the client may optionally consult an external D-Bus service before proceeding.
+The service is configured via `soft_update_check_dbus_service` in the [client] section.
+"""
+
+import pytest
+
+from helper import run, run_pexpect
+from soft_update_check_dbus_dummy import DBUS_SERVICE_NAME
+
+
+SOFT_PARAMS = {'type': 'soft'}
+FORCED_PARAMS = {'type': 'forced'}
+
+
+@pytest.fixture
+def soft_update_config(config, adjust_config):
+    """Adjusts the base config to add the soft update check D-Bus service name."""
+    return adjust_config({'client': {'soft_update_check_dbus_service': DBUS_SERVICE_NAME}})
+
+
+def test_soft_update_no_check_configured(hawkbit, config, assign_bundle,
+                                         rauc_dbus_install_success):
+    """
+    Soft update without soft_update_check_dbus_service configured: update proceeds
+    unconditionally, same as a forced update.
+    """
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{config}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Software bundle installed successfully.' in out
+    assert err == ''
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] == 'finished'
+
+
+def test_soft_update_permitted(hawkbit, soft_update_config, assign_bundle,
+                               rauc_dbus_install_success, soft_update_check_permitted):
+    """
+    Soft update with readiness check configured and service returning True: update proceeds
+    after permission is granted.
+    """
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{soft_update_config}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Soft update permission granted.' in out
+    assert 'Software bundle installed successfully.' in out
+    assert err == ''
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] == 'finished'
+
+
+def test_soft_update_denied(hawkbit, soft_update_config, assign_bundle,
+                            soft_update_check_denied):
+    """
+    Soft update with readiness check configured and service returning False: update is skipped
+    without error and hawkBit action remains open.
+    """
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{soft_update_config}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Soft update permission denied, skipping update.' in out
+    assert 'Software bundle installed successfully.' not in out
+    assert err == ''
+    assert exitcode == 0
+
+    # action must remain open (not finished/error) since the update was skipped
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] not in ('finished', 'error')
+
+
+def test_soft_update_no_dbus_service(hawkbit, soft_update_config, assign_bundle,
+                                     rauc_dbus_install_success):
+    """
+    Soft update with readiness check configured but the D-Bus service not running: update is
+    forced through by default (soft_update_check_force_on_unavailable defaults to true).
+    """
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{soft_update_config}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Soft update permission service unavailable:' in err
+    assert 'Forcing update.' in err
+    assert 'Software bundle installed successfully.' in out
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] == 'finished'
+
+
+def test_soft_update_no_dbus_service_skip_on_unavailable(hawkbit, config, adjust_config,
+                                                         assign_bundle):
+    """
+    Soft update with readiness check configured, service not running, and
+    soft_update_check_force_on_unavailable=false: update is skipped and hawkBit action remains
+    open.
+    """
+    adjusted = adjust_config({'client': {
+        'soft_update_check_dbus_service': DBUS_SERVICE_NAME,
+        'soft_update_check_force_on_unavailable': 'false',
+    }})
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{adjusted}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Soft update permission check failed:' in err
+    assert 'Software bundle installed successfully.' not in out
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] not in ('finished', 'error')
+
+
+def test_forced_update_bypasses_check(hawkbit, soft_update_config, assign_bundle,
+                                      rauc_dbus_install_success, soft_update_check_denied):
+    """
+    Forced update with readiness check configured and service returning False: the check is
+    not consulted for forced updates, so the update proceeds unconditionally.
+    """
+    assign_bundle(params=FORCED_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{soft_update_config}" -r')
+
+    assert 'Action type: Forced.' in out
+    assert 'Soft update permission' not in out
+    assert 'Software bundle installed successfully.' in out
+    assert err == ''
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] == 'finished'

--- a/test/test_soft.py
+++ b/test/test_soft.py
@@ -8,7 +8,11 @@ updates in that the client may optionally consult an external D-Bus service befo
 The service is configured via `soft_update_check_dbus_service` in the [client] section.
 """
 
+import os
+import sys
+
 import pytest
+from pexpect import EOF
 
 from helper import run, run_pexpect
 from soft_update_check_dbus_dummy import DBUS_SERVICE_NAME
@@ -143,6 +147,178 @@ def test_forced_update_bypasses_check(hawkbit, soft_update_config, assign_bundle
     assert 'Software bundle installed successfully.' in out
     assert err == ''
     assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] == 'finished'
+
+
+def test_soft_update_unavailable_retry_no_max(hawkbit, config, adjust_config, assign_bundle):
+    """
+    When max_retries is not set (defaults to 0) and the D-Bus service is unreachable, the
+    warning shows the attempt count without an upper bound. The update is skipped; the counter
+    never triggers a forced install.
+    """
+    adjusted = adjust_config({'client': {
+        'soft_update_check_dbus_service': DBUS_SERVICE_NAME,
+        'soft_update_check_force_on_unavailable': 'false',
+    }})
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{adjusted}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Soft update permission service unavailable (attempt 1):' in err
+    assert 'attempt 1/' not in err  # no "/N" upper bound in the message
+    assert 'Forcing update.' not in err
+    assert 'Software bundle installed successfully.' not in out
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] not in ('finished', 'error')
+
+
+def test_soft_update_unavailable_retry_skip_below_max(hawkbit, config, adjust_config,
+                                                      assign_bundle):
+    """
+    When max_retries=3 and the D-Bus service is unreachable on the first poll, the warning
+    shows 'attempt 1/3' and the update is skipped. The max has not been reached so no
+    forcing occurs.
+    """
+    adjusted = adjust_config({'client': {
+        'soft_update_check_dbus_service': DBUS_SERVICE_NAME,
+        'soft_update_check_force_on_unavailable': 'false',
+        'soft_update_check_unavailable_max_retries': '3',
+    }})
+    assign_bundle(params=SOFT_PARAMS)
+
+    out, err, exitcode = run(f'rauc-hawkbit-updater -c "{adjusted}" -r')
+
+    assert 'Action type: Soft.' in out
+    assert 'Soft update permission service unavailable (attempt 1/3):' in err
+    assert 'Forcing update.' not in err
+    assert 'Software bundle installed successfully.' not in out
+    assert exitcode == 0
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] not in ('finished', 'error')
+
+
+def test_soft_update_unavailable_retry_force_after_max_retries(hawkbit, config, adjust_config,
+                                                                assign_bundle,
+                                                                rauc_dbus_install_success):
+    """
+    When max_retries=2 and the D-Bus service is unreachable for 2 consecutive poll cycles,
+    the client forces the update on the 2nd cycle. This prevents a permanently unavailable
+    service from blocking updates indefinitely.
+
+    Note: this test runs in daemon mode and waits for 2 poll cycles at the minimum hawkBit
+    polling interval (00:00:30), so it takes ~35 seconds to complete.
+    """
+    adjusted = adjust_config({'client': {
+        'soft_update_check_dbus_service': DBUS_SERVICE_NAME,
+        'soft_update_check_force_on_unavailable': 'false',
+        'soft_update_check_unavailable_max_retries': '2',
+    }})
+    assign_bundle(params=SOFT_PARAMS)
+
+    proc = run_pexpect(f'rauc-hawkbit-updater -c "{adjusted}"', timeout=90)
+
+    # Poll 1: service unavailable, skip
+    proc.expect('Soft update permission service unavailable \\(attempt 1/2\\):')
+
+    # Poll 2: service still unavailable, max retries reached, update forced
+    proc.expect('Soft update permission service unavailable for 2 consecutive poll cycles')
+    proc.expect('Forcing update\\.')
+    proc.expect('Software bundle installed successfully\\.')
+
+    proc.terminate(force=True)
+    proc.expect(EOF)
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] == 'finished'
+
+
+def test_soft_update_unavailable_then_denied(hawkbit, config, adjust_config, assign_bundle):
+    """
+    Service unavailable on poll 1 (counter=1), then available but denying on poll 2: the
+    update is skipped and the action remains open.
+
+    Verifies that the counter resets on recovery (no spurious forcing) and that an explicit
+    denial is still honored once the service comes back.
+
+    Note: runs in daemon mode, takes ~35 seconds (one 30s inter-poll sleep).
+    """
+    adjusted = adjust_config({'client': {
+        'soft_update_check_dbus_service': DBUS_SERVICE_NAME,
+        'soft_update_check_force_on_unavailable': 'false',
+        'soft_update_check_unavailable_max_retries': '3',
+    }})
+    assign_bundle(params=SOFT_PARAMS)
+
+    proc = run_pexpect(f'rauc-hawkbit-updater -c "{adjusted}"', timeout=90)
+
+    # Poll 1: service not running, counter increments to 1, update skipped
+    proc.expect('Soft update permission service unavailable \\(attempt 1/3\\):')
+
+    # Bring up the service between polls — it will deny permission
+    dbus_proc = run_pexpect(
+        f'{sys.executable} -m soft_update_check_dbus_dummy --denied',
+        cwd=os.path.dirname(__file__)
+    )
+    dbus_proc.expect('Interface published')
+
+    # Poll 2: service reachable, returns False — explicit denial, counter reset to 0
+    proc.expect('Soft update permission denied, skipping update\\.')
+
+    proc.terminate(force=True)
+    proc.expect(EOF)
+    assert dbus_proc.isalive()
+    dbus_proc.terminate(force=True)
+    dbus_proc.expect(EOF)
+
+    status = hawkbit.get_action_status()
+    assert status[0]['type'] not in ('finished', 'error')
+
+
+def test_soft_update_unavailable_then_permitted(hawkbit, config, adjust_config, assign_bundle,
+                                                rauc_dbus_install_success):
+    """
+    Service unavailable on poll 1 (counter=1), then available and granting permission on
+    poll 2: the update is applied.
+
+    Verifies that the counter resets on recovery and the update proceeds normally once the
+    service grants permission, without any forced-update path being taken.
+
+    Note: runs in daemon mode, takes ~35 seconds (one 30s inter-poll sleep).
+    """
+    adjusted = adjust_config({'client': {
+        'soft_update_check_dbus_service': DBUS_SERVICE_NAME,
+        'soft_update_check_force_on_unavailable': 'false',
+        'soft_update_check_unavailable_max_retries': '3',
+    }})
+    assign_bundle(params=SOFT_PARAMS)
+
+    proc = run_pexpect(f'rauc-hawkbit-updater -c "{adjusted}"', timeout=90)
+
+    # Poll 1: service not running, counter increments to 1, update skipped
+    proc.expect('Soft update permission service unavailable \\(attempt 1/3\\):')
+
+    # Bring up the service between polls — it will grant permission
+    dbus_proc = run_pexpect(
+        f'{sys.executable} -m soft_update_check_dbus_dummy',
+        cwd=os.path.dirname(__file__)
+    )
+    dbus_proc.expect('Interface published')
+
+    # Poll 2: service reachable, returns True — permission granted, install proceeds
+    proc.expect('Soft update permission granted\\.')
+    proc.expect('Software bundle installed successfully\\.')
+
+    proc.terminate(force=True)
+    proc.expect(EOF)
+    assert dbus_proc.isalive()
+    dbus_proc.terminate(force=True)
+    dbus_proc.expect(EOF)
 
     status = hawkbit.get_action_status()
     assert status[0]['type'] == 'finished'


### PR DESCRIPTION
HawkBit supports four rollout action types: Forced, Soft, Time Forced, and Download Only.

Before this change, the updater did not distinguish between Forced and Soft, all deployments that reached the install step were treated identically regardless of whether hawkBit signalled the update as being at the device's discretion (soft mode).

So I made the following changes to support it:

- Action type detection (`src/hawkbit-client.c`): The updater now infers the action type from the deployment handling fields (download/update) and logs it on each poll cycle. This makes behavior more transparent and is the foundation for type-specific handling.

- Soft update readiness gate: For soft updates (DDI fields download=attempt, update=attempt), the updater can optionally call IsReadyForUpdate() on a configurable D-Bus service (system bus) before proceeding. The rationale is that hawkBit's Soft semantic explicitly leaves the installation decision to the device, so it is appropriate to let another application (such as a UI or workload manager) gate the update (e.g. to defer it until the device is idle or the user has consented).

  - If the service returns True, the update proceeds normally.

  - If it returns False, the update is silently skipped; no error is reported to hawkBit, so the action remains open and the check is retried on the next poll cycle (controlled by retry_wait).

    - Forced and Download Only updates bypass this check entirely — they are applied unconditionally as before.
    - Time Forced actions report as Soft until their deadline; hawkBit then transparently switches them to Forced, so they will bypass the check once forced.

- New configuration keys (`config.conf.example`, `include/config-file.h`, `src/config-file.c`):
  ```
    [client]
    # D-Bus well-known name of the permission service (unset = no check)
    soft_update_check_dbus_service = de.example.SoftUpdateCheck

    # When the service is unreachable: true (default) = force the update, false = skip it
    soft_update_check_force_on_unavailable = true
  ```

- Documentation (README.md): A new Soft Update Permission Check section documents the feature, the expected D-Bus interface, and the required system bus policy file.
  

- Tests (`test/test_soft.py`, `test/soft_update_check_dbus_dummy.py`, `test/conftest.py`): Six integration tests cover the full matrix of scenarios:
  - Soft update with no check configured (unconditional install)
  - Check configured, service grants permission (install proceeds)
  - Check configured, service denies permission (update skipped, hawkBit action left open)
  - Check configured, service unreachable, force_on_unavailable=true (default — install forced through)
  - Check configured, service unreachable, force_on_unavailable=false (update skipped)
  - Forced update with a denying service configured (check bypassed, install proceeds)

A D-Bus dummy service (soft_update_check_dbus_dummy.py) is provided for use in tests and manual verification.