### PR TITLE
hawkbit-client: fix artifact size error check

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1256,7 +1256,7 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
                 goto proc_error;
 
         artifact->size = json_get_int(json_artifact, "$.size", error);
-        if (!artifact->size && error)
+        if (!artifact->size && *error)
                 goto proc_error;
 
         artifact->sha1 = json_get_string(json_artifact, "$.hashes.sha1", error);


### PR DESCRIPTION
Actually check if json_get_int() set an error, not if the pointer exists. Artifacts of size 0 won't happen in the real world, but the check should be corrected nonetheless.