### PR TITLE
hawkbit-client: add strptime() error check

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -766,7 +766,7 @@ static long json_get_sleeptime(JsonNode *root)
 {
         g_autofree gchar *sleeptime_str = NULL;
         g_autoptr(GError) error = NULL;
-        struct tm time;
+        struct tm time = {0};
 
         g_return_val_if_fail(root, 0L);
 
@@ -788,7 +788,11 @@ static long json_get_sleeptime(JsonNode *root)
                 return hawkbit_config->retry_wait;
         }
 
-        strptime(sleeptime_str, "%T", &time);
+        if (!strptime(sleeptime_str, "%T", &time)) {
+                g_warning("Invalid polling sleep time: %s. Using fallback: %ds",
+                          sleeptime_str, hawkbit_config->retry_wait);
+                return hawkbit_config->retry_wait;
+        }
         return (time.tm_sec + (time.tm_min * 60) + (time.tm_hour * 60 * 60));
 }
 


### PR DESCRIPTION
Check for strptime() parsing failures, issue a warning and return the default config `retry_wait` value. We should not run into such issues since the value is hawkBit-controlled, but better be safe than sorry.

While at it, initialize the tm struct, so reading unfilled fields does not lead to undefined behavior. This is for good measure only since %T fills all fields currently used.